### PR TITLE
feat: declare exports explicitly

### DIFF
--- a/.changeset/hot-insects-jump.md
+++ b/.changeset/hot-insects-jump.md
@@ -1,0 +1,5 @@
+---
+'@polymorphic-factory/react': minor
+---
+
+Declared bundle exports explicitly. 

--- a/.changeset/many-steaks-explode.md
+++ b/.changeset/many-steaks-explode.md
@@ -1,0 +1,5 @@
+---
+'@polymorphic-factory/react': patch
+---
+
+Fixed an issue where autocomplete for intrinsic element props did not show up.

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -1,11 +1,11 @@
 import {
-  ComponentProps,
-  ComponentPropsWithoutRef,
-  ElementType,
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ElementType,
+  type ForwardRefRenderFunction,
+  type ValidationMap,
+  type WeakValidationMap,
   forwardRef as forwardRefReact,
-  ForwardRefRenderFunction,
-  ValidationMap,
-  WeakValidationMap,
 } from 'react'
 
 /**
@@ -15,20 +15,28 @@ export type PropsOf<T extends ElementType> = ComponentPropsWithoutRef<T> & {
   as?: ElementType
 }
 
+/**
+ * Assign property types from right to left.
+ * Think `Object.assign` for types.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+ */
+export type Assign<Target, Source> = Omit<Target, keyof Source> & Source
+
 export type OmitCommonProps<
   Target,
   OmitAdditionalProps extends string | number | symbol = never,
 > = Omit<Target, 'transition' | 'as' | 'color' | OmitAdditionalProps>
 
-export type AssignCommon<
-  SourceProps extends object = Record<string, unknown>,
-  OverrideProps extends object = Record<string, unknown>,
-> = OmitCommonProps<SourceProps, keyof OverrideProps> & OverrideProps
+type AssignCommon<
+  SourceProps extends object = Record<never, never>,
+  OverrideProps extends object = Record<never, never>,
+> = Assign<OmitCommonProps<SourceProps>, OverrideProps>
 
-export type MergeWithAs<
-  ComponentProps extends Record<string, unknown>,
-  AsProps extends Record<string, unknown>,
-  AdditionalProps extends Record<string, unknown> = Record<string, unknown>,
+type MergeWithAs<
+  ComponentProps extends object,
+  AsProps extends object,
+  AdditionalProps extends object = Record<never, never>,
   AsComponent extends ElementType = ElementType,
 > = AssignCommon<ComponentProps, AdditionalProps> &
   AssignCommon<AsProps, AdditionalProps> & {
@@ -37,7 +45,7 @@ export type MergeWithAs<
 
 export type ComponentWithAs<
   Component extends ElementType,
-  Props extends Record<string, unknown> = Record<string, unknown>,
+  Props extends object = Record<never, never>,
 > = {
   <AsComponent extends ElementType = Component>(
     props: MergeWithAs<ComponentProps<Component>, ComponentProps<AsComponent>, Props, AsComponent>,
@@ -52,7 +60,7 @@ export type ComponentWithAs<
 
 export function forwardRef<
   Component extends ElementType,
-  Props extends Record<string, unknown> = Record<string, unknown>,
+  Props extends object = Record<never, never>,
 >(
   component: ForwardRefRenderFunction<
     unknown,

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -29,14 +29,14 @@ export type OmitCommonProps<
 > = Omit<Target, 'transition' | 'as' | 'color' | OmitAdditionalProps>
 
 type AssignCommon<
-  SourceProps extends object = Record<never, never>,
-  OverrideProps extends object = Record<never, never>,
+  SourceProps extends Record<string, unknown> = Record<never, never>,
+  OverrideProps extends Record<string, unknown> = Record<never, never>,
 > = Assign<OmitCommonProps<SourceProps>, OverrideProps>
 
 type MergeWithAs<
-  ComponentProps extends object,
-  AsProps extends object,
-  AdditionalProps extends object = Record<never, never>,
+  ComponentProps extends Record<string, unknown>,
+  AsProps extends Record<string, unknown>,
+  AdditionalProps extends Record<string, unknown> = Record<never, never>,
   AsComponent extends ElementType = ElementType,
 > = AssignCommon<ComponentProps, AdditionalProps> &
   AssignCommon<AsProps, AdditionalProps> & {
@@ -45,7 +45,7 @@ type MergeWithAs<
 
 export type ComponentWithAs<
   Component extends ElementType,
-  Props extends object = Record<never, never>,
+  Props extends Record<string, unknown> = Record<never, never>,
 > = {
   <AsComponent extends ElementType = Component>(
     props: MergeWithAs<ComponentProps<Component>, ComponentProps<AsComponent>, Props, AsComponent>,
@@ -60,7 +60,7 @@ export type ComponentWithAs<
 
 export function forwardRef<
   Component extends ElementType,
-  Props extends object = Record<never, never>,
+  Props extends Record<string, unknown> = Record<never, never>,
 >(
   component: ForwardRefRenderFunction<
     unknown,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,6 @@
-export * from './forwardRef'
-export * from './polymorphic-factory'
+export { forwardRef, type ComponentWithAs, type PropsOf, type Assign } from './forwardRef'
+export {
+  polymorphicFactory,
+  type HTMLPolymorphicComponents,
+  type HTMLPolymorphicProps,
+} from './polymorphic-factory'

--- a/packages/react/src/polymorphic-factory.tsx
+++ b/packages/react/src/polymorphic-factory.tsx
@@ -14,7 +14,7 @@ export type HTMLPolymorphicProps<T extends ElementType> = Omit<PropsOf<T>, 'ref'
 type PolymorphFactory = {
   <
     T extends ElementType,
-    P extends Record<string, unknown> = Record<string, unknown>,
+    P extends Record<string, unknown> = Record<never, never>,
     Options = never,
   >(
     component: T,

--- a/packages/react/src/polymorphic-factory.tsx
+++ b/packages/react/src/polymorphic-factory.tsx
@@ -1,7 +1,7 @@
-import { ElementType } from 'react'
-import { ComponentWithAs, forwardRef, PropsOf } from './forwardRef'
+import type { ElementType } from 'react'
+import { type ComponentWithAs, forwardRef, type PropsOf } from './forwardRef'
 
-export type DOMElements = keyof JSX.IntrinsicElements
+type DOMElements = keyof JSX.IntrinsicElements
 
 export type HTMLPolymorphicComponents = {
   [Tag in DOMElements]: ComponentWithAs<Tag>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "noEmit": false
+    "noEmit": false,
+    "importsNotUsedAsValues": "error"
   }
 }


### PR DESCRIPTION
This PR 
- declares the bundle exports explicitly
- fixes an issue where autocomplete for intrinsic element props did not show up