### PR TITLE
feat: add polymorphic factory for solid

### DIFF
--- a/.changeset/wicked-parrots-cry.md
+++ b/.changeset/wicked-parrots-cry.md
@@ -1,0 +1,5 @@
+---
+'@polymorphic-factory/solid': minor
+---
+
+Initial release for solid-js.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,39 @@
   <img alt="Github Stars" src="https://badgen.net/github/stars/chakra-ui/polymorphic" />
 </p>
 
-## What's inside?
+Create polymorphic React/SolidJS components with a customizable `styled` function.
+
+A polymorphic component is a component that can be rendered with a different element.
+
+```tsx
+import { polymorphicFactory } from '@polymorphic-factory/{react,solid}'
+
+const poly = polymorphicFactory()
+
+const App = () => (
+  <>
+    <poly.div />
+    <poly.main>
+      <poly.section>
+        <poly.div as="p">This is rendered as a p element</poly.div>
+      </poly.section>
+    </poly.main>
+  </>
+)
+```
+
+> **Known drawbacks for the type definitions:**
+>
+> Event handlers are not typed correctly when using the `as` prop.
+>
+> This is a deliberate decision to keep the usage as simple as possible.
 
 This turborepo uses [pnpm](https://pnpm.io) as a package manager. It includes the following packages:
 
 ### Packages
 
 - [react](./packages/react/README.md)
+- [solid](./packages/solid/README.md)
 
 ### Build
 

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -29,8 +29,8 @@ export type OmitCommonProps<
 > = Omit<Target, 'transition' | 'as' | 'color' | OmitAdditionalProps>
 
 type AssignCommon<
-  SourceProps extends Record<never, never> = Record<never, never>,
-  OverrideProps extends Record<never, never> = Record<never, never>,
+  SourceProps extends Record<string, unknown> = Record<never, never>,
+  OverrideProps extends Record<string, unknown> = Record<never, never>,
 > = Assign<OmitCommonProps<SourceProps>, OverrideProps>
 
 type MergeWithAs<

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -29,8 +29,8 @@ export type OmitCommonProps<
 > = Omit<Target, 'transition' | 'as' | 'color' | OmitAdditionalProps>
 
 type AssignCommon<
-  SourceProps extends Record<string, unknown> = Record<never, never>,
-  OverrideProps extends Record<string, unknown> = Record<never, never>,
+  SourceProps extends Record<never, never> = Record<never, never>,
+  OverrideProps extends Record<never, never> = Record<never, never>,
 > = Assign<OmitCommonProps<SourceProps>, OverrideProps>
 
 type MergeWithAs<

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,0 +1,132 @@
+<h1 align="center">@polymorphic-factory/solid</h1>
+
+<p align="center">
+  <img alt="CodeCov" src="https://codecov.io/gh/chakra-ui/polymorphic/branch/main/graph/badge.svg?token=GISB4HXIK7"/>
+  <img alt="MIT License" src="https://img.shields.io/github/license/chakra-ui/polymorphic"/>
+  <img alt="Github Stars" src="https://badgen.net/github/stars/chakra-ui/polymorphic" />
+  <img alt="Bundle Size" src="https://badgen.net/bundlephobia/minzip/@polymorphic-factory/solid"/>
+  <img alt="NPM Downloads" src="https://img.shields.io/npm/dm/@polymorphic-factory/solid?style=flat"/>
+</p>
+
+Create polymorphic SolidJS components with a customizable `styled` function.
+
+A polymorphic component is a component that can be rendered with a different element.
+
+> **Known drawbacks for the type definitions:**
+>
+> Event handlers are not typed correctly when using the `as` prop.
+>
+> This is a deliberate decision to keep the usage as simple as possible.
+
+## Installation
+
+```bash
+npm install @polymorphic-factory/solid
+```
+
+or
+
+```bash
+yarn add @polymorphic-factory/solid
+```
+
+or
+
+```bash
+pnpm install @polymorphic-factory/solid
+```
+
+## Usage
+
+Import the polymorphic factory and create your element factory.
+
+```ts
+import { polymorphicFactory } from '@polymorphic-factory/solid'
+const poly = polymorphicFactory()
+```
+
+### Custom `styled` function
+
+You can override the default implementation by passing `styled` function in the options.
+
+```tsx
+import { Dynamic } from 'solid-js/web'
+
+const poly = polymorphicFactory({
+  styled: (component, options) => (props) => {
+    const [local, others] = splitProps(props, ['as'])
+    const component = local.as || originalComponent
+
+    return (
+      <Dynamic
+        component={component}
+        data-custom-styled
+        data-options={JSON.stringify(options)}
+        {...others}
+      />
+    )
+  },
+})
+
+const WithOptions = poly('div', { hello: 'world' })
+
+const App = () => {
+  return (
+    <>
+      <poly.div hello="world" />
+      {/* renders <div data-custom-styled hello="world" /> */}
+
+      <WithOptions />
+      {/* renders <div data-custom-styled data-options="{ \"hello\": \"world\" }" /> */}
+    </>
+  )
+}
+```
+
+### Inline
+
+Use the element factory to create elements inline.
+Every JSX element is supported `div`, `main`, `aside`, etc.
+
+```tsx
+<>
+  <poly.div />
+  <poly.main>
+    <poly.section>
+      <poly.div as="p">This is rendered as a p element</poly.div>
+    </poly.section>
+  </poly.main>
+</>
+```
+
+### Factory
+
+Use the factory to wrap custom components.
+
+```tsx
+const OriginalComponent = (props) => <div data-original="true" {...props}></div>
+const MyComponent = poly(OriginalComponent)
+
+const App = () => <MyComponent />
+// render <div data-original="true" />
+```
+
+It still supports the `as` prop, which would replace the `OriginalComponent`.
+
+```tsx
+<MyComponent as="div" />
+// renders <div />
+```
+
+## Types
+
+```ts
+import type { HTMLPolymorphicComponents, HTMLPolymorphicProps } from '@polymorphic-factory/solid'
+
+type PolymorphicDiv = HTMLPolymorphicComponents['div']
+type DivProps = HTMLPolymorphicProps<'div'>
+```
+
+## License
+
+MIT © [Tim Kolberger](https://github.com/timkolberger)

--- a/packages/solid/clean-package.config.json
+++ b/packages/solid/clean-package.config.json
@@ -1,0 +1,14 @@
+{
+  "replace": {
+    "main": "dist/index.cjs.js",
+    "module": "dist/index.esm.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": "./dist/index.esm.js",
+        "require": "./dist/index.cjs.js"
+      },
+      "./package.json": "./package.json"
+    }
+  }
+}

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@polymorphic-factory/solid",
+  "version": "0.0.0",
+  "description": "",
+  "keywords": [],
+  "homepage": "https://github.com/chakra-ui/polymorphic",
+  "author": "Tim Kolberger <tim@kolberger.eu>",
+  "license": "MIT",
+  "main": "src/index.ts",
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/chakra-ui/polymorphic.git",
+    "directory": "packages/react"
+  },
+  "bugs": {
+    "url": "https://github.com/chakra-ui/polymorphic/issues"
+  },
+  "scripts": {
+    "dev": "pnpm run build --watch",
+    "build": "tsup src/index.ts",
+    "test": "vitest run --reporter verbose --coverage",
+    "test:watch": "vitest",
+    "lint": "eslint --ext .ts,.tsx src",
+    "typecheck": "tsc --noEmit",
+    "prepack": "clean-package",
+    "postpack": "clean-package restore"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "8.19.0",
+    "@testing-library/jest-dom": "5.16.5",
+    "@types/jsdom": "20.0.1",
+    "@types/testing-library__jest-dom": "5.14.5",
+    "@vitest/coverage-c8": "0.25.1",
+    "jsdom": "20.0.2",
+    "solid-js": "1.6.1",
+    "solid-testing-library": "0.5.0",
+    "tsup": "6.4.0",
+    "typescript": "4.8.4",
+    "vite": "3.2.3",
+    "vitest": "0.25.1",
+    "vite-plugin-solid": "2.4.0"
+  },
+  "peerDependencies": {
+    "solid-js": ">=1.6.0"
+  }
+}

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -17,7 +17,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chakra-ui/polymorphic.git",
-    "directory": "packages/react"
+    "directory": "packages/solid"
   },
   "bugs": {
     "url": "https://github.com/chakra-ui/polymorphic/issues"

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  polymorphicFactory,
+  type HTMLPolymorphicComponents,
+  type HTMLPolymorphicProps,
+  type ComponentWithAs,
+  type PropsOf,
+  type Assign,
+} from './polymorphic-factory'

--- a/packages/solid/src/polymorphic-factory.tsx
+++ b/packages/solid/src/polymorphic-factory.tsx
@@ -1,0 +1,102 @@
+import { ValidComponent, Component, JSX, ComponentProps, splitProps } from 'solid-js'
+import { Dynamic } from 'solid-js/web'
+
+type DOMElements = keyof JSX.IntrinsicElements
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ElementType = DOMElements | Component<any>
+
+/**
+ * Assign property types from right to left.
+ * Think `Object.assign` for types.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+ */
+export type Assign<Target, Source> = Omit<Target, keyof Source> & Source
+
+/**
+ * Extract the props of a solid element or component
+ */
+export type PropsOf<T extends ElementType> = ComponentProps<T> & {
+  as?: ElementType
+}
+
+export type ComponentWithAs<T extends ValidComponent, Props = Record<never, never>> = Component<
+  Assign<Assign<ComponentProps<T>, Props>, { as?: ElementType }>
+>
+
+export type HTMLPolymorphicComponents = {
+  [Tag in DOMElements]: ComponentWithAs<Tag>
+}
+
+export type HTMLPolymorphicProps<T extends ElementType> = Omit<ComponentProps<T>, 'ref'> & {
+  as?: ElementType
+}
+
+type PolymorphFactory = {
+  <
+    T extends ElementType,
+    P extends Record<string, unknown> = Record<never, never>,
+    Options = never,
+  >(
+    component: T,
+    option?: Options,
+  ): ComponentWithAs<T, P>
+}
+
+function defaultStyled(originalComponent: ElementType) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (props: ComponentProps<ComponentWithAs<any>>) => {
+    const [local, others] = splitProps(props, ['as'])
+    const component = local.as || originalComponent
+
+    return <Dynamic component={component} {...others} />
+  }
+}
+
+interface PolyFactoryParam<
+  Component extends ElementType,
+  Props extends Record<string, unknown>,
+  Options,
+> {
+  styled?: (component: Component, options?: Options) => ComponentWithAs<Component, Props>
+}
+
+/**
+ * Create a polymorphic factory, which is an object of JSX elements to render React Components accepting the `as` prop.
+ *
+ * @example
+ * const poly = polymorphicFactory()
+ * <poly.div /> // => renders div
+ * <poly.main /> // => renders main
+ * <poly.section as="main" /> => // renders main
+ */
+export function polymorphicFactory<
+  Component extends ElementType,
+  Props extends Record<string, unknown>,
+  Options = never,
+>({ styled = defaultStyled }: PolyFactoryParam<Component, Props, Options> = {}) {
+  const cache = new Map<Component, ComponentWithAs<Component, Props>>()
+
+  return new Proxy(styled, {
+    /**
+     * @example
+     * const Div = poly("div")
+     * const WithPoly = poly(AnotherComponent)
+     */
+    apply(target, thisArg, argArray: [Component, Options]) {
+      return styled(...argArray)
+    },
+    /**
+     * @example
+     * <poly.div />
+     */
+    get(_, element) {
+      const asElement = element as Component
+      if (!cache.has(asElement)) {
+        cache.set(asElement, styled(asElement))
+      }
+      return cache.get(asElement)
+    },
+  }) as PolymorphFactory & HTMLPolymorphicComponents
+}

--- a/packages/solid/src/polymorphic-factory.tsx
+++ b/packages/solid/src/polymorphic-factory.tsx
@@ -3,6 +3,7 @@ import { Dynamic } from 'solid-js/web'
 
 type DOMElements = keyof JSX.IntrinsicElements
 
+// any is required for the import('solid/web').ValidComponent typings:
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ElementType = DOMElements | Component<any>
 
@@ -45,6 +46,7 @@ type PolymorphFactory = {
 }
 
 function defaultStyled(originalComponent: ElementType) {
+  // any is required for the import('solid/web').ValidComponent typings:
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (props: ComponentProps<ComponentWithAs<any>>) => {
     const [local, others] = splitProps(props, ['as'])

--- a/packages/solid/test/polymorphic-factory.test.tsx
+++ b/packages/solid/test/polymorphic-factory.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from 'solid-testing-library'
+import { polymorphicFactory } from '../src'
+import { splitProps } from 'solid-js'
+import { Dynamic } from 'solid-js/web'
+
+describe('Polymorphic Factory', () => {
+  describe('with default styled function', () => {
+    const poly = polymorphicFactory()
+
+    it('should render an element', () => {
+      render(() => <poly.div data-testid="poly" />)
+      const element = screen.getByTestId('poly')
+      expect(element.nodeName).toBe('DIV')
+    })
+
+    it('should render an element with the as prop', () => {
+      render(() => <poly.div data-testid="poly" as="main" />)
+      const element = screen.getByTestId('poly')
+      expect(element.nodeName).toBe('MAIN')
+    })
+
+    it('should render an element with the factory', () => {
+      const Aside = poly('aside')
+      render(() => <Aside data-testid="poly" />)
+      const element = screen.getByTestId('poly')
+      expect(element.nodeName).toBe('ASIDE')
+    })
+  })
+
+  describe('with custom styled function', () => {
+    const customPoly = polymorphicFactory({
+      styled: (originalComponent, options) => (props) => {
+        const [local, others] = splitProps(props, ['as'])
+        const component = local.as || originalComponent
+
+        return (
+          <Dynamic
+            component={component}
+            data-custom-styled
+            data-options={JSON.stringify(options)}
+            {...others}
+          />
+        )
+      },
+    })
+
+    it('should render an element', () => {
+      render(() => <customPoly.div data-testid="poly" />)
+      const element = screen.getByTestId('poly')
+      expect(element.nodeName).toBe('DIV')
+      expect(element).toHaveAttribute('data-custom-styled', 'true')
+    })
+
+    it('should render an element with the as prop', () => {
+      render(() => <customPoly.div data-testid="poly" as="main" />)
+      const element = screen.getByTestId('poly')
+      expect(element.nodeName).toBe('MAIN')
+    })
+
+    it('should render an element with the custom factory', () => {
+      const Aside = customPoly('aside')
+      render(() => <Aside data-testid="custom-poly" />)
+      const element = screen.getByTestId('custom-poly')
+      expect(element.nodeName).toBe('ASIDE')
+      expect(element).toHaveAttribute('data-custom-styled', 'true')
+    })
+
+    it('should render an element with styled options', () => {
+      const options = { customOption: 'awesome' }
+      const Aside = customPoly('aside', options)
+
+      render(() => <Aside data-testid="custom-poly" />)
+
+      const element = screen.getByTestId('custom-poly')
+      expect(element.nodeName).toBe('ASIDE')
+      expect(element).toHaveAttribute('data-custom-styled', 'true')
+      expect(element).toHaveAttribute('data-options', JSON.stringify(options))
+    })
+  })
+})

--- a/packages/solid/test/setupTest.ts
+++ b/packages/solid/test/setupTest.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
+  },
+  "include": ["src", "test"]
+}

--- a/packages/solid/tsup.config.ts
+++ b/packages/solid/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  clean: true,
+  format: ['cjs', 'esm'],
+  dts: true,
+  outExtension(ctx) {
+    return { js: `.${ctx.format}.js` }
+  },
+})

--- a/packages/solid/vite.config.ts
+++ b/packages/solid/vite.config.ts
@@ -1,0 +1,19 @@
+/// <reference types="vitest" />
+/// <reference types="vite/client" />
+
+import { defineConfig } from 'vite'
+import solid from 'vite-plugin-solid'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  test: {
+    setupFiles: './test/setupTest.ts',
+    globals: true,
+    environment: 'jsdom',
+    css: false,
+  },
+  plugins: [solid()],
+  resolve: {
+    conditions: ['development', 'browser'],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,36 @@ importers:
       vite: 3.2.3
       vitest: 0.25.2_jsdom@20.0.2
 
+  packages/solid:
+    specifiers:
+      '@testing-library/dom': 8.19.0
+      '@testing-library/jest-dom': 5.16.5
+      '@types/jsdom': 20.0.1
+      '@types/testing-library__jest-dom': 5.14.5
+      '@vitest/coverage-c8': 0.25.1
+      jsdom: 20.0.2
+      solid-js: 1.6.1
+      solid-testing-library: 0.5.0
+      tsup: 6.4.0
+      typescript: 4.8.4
+      vite: 3.2.3
+      vite-plugin-solid: 2.4.0
+      vitest: 0.25.1
+    devDependencies:
+      '@testing-library/dom': 8.19.0
+      '@testing-library/jest-dom': 5.16.5
+      '@types/jsdom': 20.0.1
+      '@types/testing-library__jest-dom': 5.14.5
+      '@vitest/coverage-c8': 0.25.1_jsdom@20.0.2
+      jsdom: 20.0.2
+      solid-js: 1.6.1
+      solid-testing-library: 0.5.0_solid-js@1.6.1
+      tsup: 6.4.0_typescript@4.8.4
+      typescript: 4.8.4
+      vite: 3.2.3
+      vite-plugin-solid: 2.4.0_solid-js@1.6.1+vite@3.2.3
+      vitest: 0.25.1_jsdom@20.0.2
+
 packages:
 
   /@adobe/css-tools/4.0.1:
@@ -144,6 +174,24 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /@babel/helper-create-class-features-plugin/7.20.2_@babel+core@7.19.6:
+    resolution: {integrity: sha512-k22GoYRAHPYr9I+Gvy2ZQlAe5mGy8BqWst2wRt8cwIufWTxrsVshhIBvYNqC80N0GSFWTsqRVexOtfzlgOEDvA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-member-expression-to-functions': 7.18.9
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.19.1
+      '@babel/helper-split-export-declaration': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-environment-visitor/7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
@@ -159,6 +207,20 @@ packages:
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.20.0
+    dev: true
+
+  /@babel/helper-member-expression-to-functions/7.18.9:
+    resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.20.0
+    dev: true
+
+  /@babel/helper-module-imports/7.16.0:
+    resolution: {integrity: sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.0
@@ -187,9 +249,34 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-optimise-call-expression/7.18.6:
+    resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.20.0
+    dev: true
+
   /@babel/helper-plugin-utils/7.19.0:
     resolution: {integrity: sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==}
     engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-plugin-utils/7.20.2:
+    resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-replace-supers/7.19.1:
+    resolution: {integrity: sha512-T7ahH7wV0Hfs46SFh5Jz3s0B6+o8g3c+7TMxu7xKfmHikg7EAZ3I2Qk9LFhjxXq8sL7UkP5JflezNwoZa8WvWw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-member-expression-to-functions': 7.18.9
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/traverse': 7.20.0
+      '@babel/types': 7.20.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/helper-simple-access/7.19.4:
@@ -259,6 +346,16 @@ packages:
       '@babel/helper-plugin-utils': 7.19.0
     dev: true
 
+  /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.19.6:
+    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.19.6:
     resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
@@ -301,6 +398,34 @@ packages:
       '@babel/helper-plugin-utils': 7.19.0
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.6
       '@babel/types': 7.20.0
+    dev: true
+
+  /@babel/plugin-transform-typescript/7.20.2_@babel+core@7.19.6:
+    resolution: {integrity: sha512-jvS+ngBfrnTUBfOQq8NfGnSbF9BrqlR6hjJ2yVxMkmO5nL/cdifNbI30EfjRlN4g5wYWNnMPyj5Sa6R1pbLeag==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-create-class-features-plugin': 7.20.2_@babel+core@7.19.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.19.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/preset-typescript/7.18.6_@babel+core@7.19.6:
+    resolution: {integrity: sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-transform-typescript': 7.20.2_@babel+core@7.19.6
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/runtime/7.20.0:
@@ -1004,6 +1129,14 @@ packages:
       pretty-format: 29.2.1
     dev: true
 
+  /@types/jsdom/20.0.1:
+    resolution: {integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==}
+    dependencies:
+      '@types/node': 18.11.9
+      '@types/tough-cookie': 4.0.2
+      parse5: 7.1.1
+    dev: true
+
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
@@ -1070,6 +1203,10 @@ packages:
     resolution: {integrity: sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==}
     dependencies:
       '@types/jest': 29.2.0
+    dev: true
+
+  /@types/tough-cookie/4.0.2:
+    resolution: {integrity: sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==}
     dev: true
 
   /@types/yargs-parser/21.0.0:
@@ -1441,6 +1578,27 @@ packages:
     engines: {node: '>= 0.4'}
     dev: true
 
+  /babel-plugin-jsx-dom-expressions/0.35.4_@babel+core@7.19.6:
+    resolution: {integrity: sha512-Ab8W+36+XcNpyb644K537MtuhZRssgE3hmZD/08a1Z99Xfnd38tR2BZaDl7yEQvvHrb46N+eje2YjIg4VGAfVQ==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-module-imports': 7.16.0
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.6
+      '@babel/types': 7.20.0
+      html-entities: 2.3.2
+    dev: true
+
+  /babel-preset-solid/1.6.2_@babel+core@7.19.6:
+    resolution: {integrity: sha512-5sFI34g7Jtp4r04YFWkuC1o+gnekBdPXQTJb5/6lmxi5YwzazVgKAXRwEAToC3zRaPyIYJbZUVLpOi5mDzPEuw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.6
+      babel-plugin-jsx-dom-expressions: 0.35.4_@babel+core@7.19.6
+    dev: true
+
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
@@ -1490,6 +1648,16 @@ packages:
 
   /bundle-require/3.1.0_esbuild@0.15.12:
     resolution: {integrity: sha512-IIXtAO7fKcwPHNPt9kY/WNVJqy7NDy6YqJvv6ENH0TOZoJ+yjpEsn1w40WKZbR2ibfu5g1rfgJTvmFHpm5aOMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.13'
+    dependencies:
+      esbuild: 0.15.12
+      load-tsconfig: 0.2.3
+    dev: true
+
+  /bundle-require/3.1.2_esbuild@0.15.12:
+    resolution: {integrity: sha512-Of6l6JBAxiyQ5axFxUM6dYeP/W7X2Sozeo/4EYB9sJhL+dqL7TKjg+shwxp6jlu/6ZSERfsYtIpSJ1/x3XkAEA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.13'
@@ -2877,6 +3045,10 @@ packages:
       whatwg-encoding: 2.0.0
     dev: true
 
+  /html-entities/2.3.2:
+    resolution: {integrity: sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==}
+    dev: true
+
   /html-escaper/2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
@@ -3185,6 +3357,11 @@ packages:
     dependencies:
       call-bind: 1.0.2
       get-intrinsic: 1.1.3
+    dev: true
+
+  /is-what/4.1.7:
+    resolution: {integrity: sha512-DBVOQNiPKnGMxRMLIYSwERAS5MVY1B7xYiGnpgctsOFvVDz9f9PFXXxMcTOHuoqYp4NK9qFYQaIC1NRRxLMpBQ==}
+    engines: {node: '>=12.13'}
     dev: true
 
   /is-windows/1.0.2:
@@ -3619,6 +3796,13 @@ packages:
       trim-newlines: 3.0.1
       type-fest: 0.18.1
       yargs-parser: 20.2.9
+    dev: true
+
+  /merge-anything/5.1.1:
+    resolution: {integrity: sha512-9fdLH+jK6l2PuIBE0qXztvnSt6bPCObqYuMulbWVlljQY7xX/hKwOnvp2oyNhbgPARVup4kJa9WkpSt8EXDzZg==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.7
     dev: true
 
   /merge-stream/2.0.0:
@@ -4275,6 +4459,14 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /rollup/3.3.0:
+    resolution: {integrity: sha512-wqOV/vUJCYEbWsXvwCkgGWvgaEnsbn4jxBQWKpN816CqsmCimDmCNJI83c6if7QVD4v/zlyRzxN7U2yDT5rfoA==}
+    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: true
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -4424,6 +4616,33 @@ packages:
       strip-ansi: 6.0.1
       wcwidth: 1.0.1
       yargs: 15.4.1
+    dev: true
+
+  /solid-js/1.6.1:
+    resolution: {integrity: sha512-i8OmR419Hr0918Or6sm1ET/cgmxTtAB7Bdz/UwhZ7G2THixrvVSO3jd+C7YqMKKfVwmf8PJ2gUSbKE8NKv28GA==}
+    dependencies:
+      csstype: 3.1.1
+    dev: true
+
+  /solid-refresh/0.4.1_solid-js@1.6.1:
+    resolution: {integrity: sha512-v3tD/OXQcUyXLrWjPW1dXZyeWwP7/+GQNs8YTL09GBq+5FguA6IejJWUvJDrLIA4M0ho9/5zK2e9n+uy+4488g==}
+    peerDependencies:
+      solid-js: ^1.3
+    dependencies:
+      '@babel/generator': 7.20.0
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/types': 7.20.0
+      solid-js: 1.6.1
+    dev: true
+
+  /solid-testing-library/0.5.0_solid-js@1.6.1:
+    resolution: {integrity: sha512-vr4Ke9Dq3bUFLaXOcN8/IVn2e9Q37w4vdmoIOmFBIPs7iCJX9IxuC0IdQqK8nzBZMQqceijkfyCE3Qc407KmaA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      solid-js: '>=1.0.0'
+    dependencies:
+      '@testing-library/dom': 8.19.0
+      solid-js: 1.6.1
     dev: true
 
   /source-map-js/1.0.2:
@@ -4823,6 +5042,42 @@ packages:
       - ts-node
     dev: true
 
+  /tsup/6.4.0_typescript@4.8.4:
+    resolution: {integrity: sha512-4OlbqIK/SF+cJp0mMqPM2pKULvgj/1S2Gm3I1aFoFGIryUOyIqPZBoqKkqVQT6uFtWJ5AHftIv0riXKfHox1zQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: ^4.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 3.1.2_esbuild@0.15.12
+      cac: 6.7.14
+      chokidar: 3.5.3
+      debug: 4.3.4
+      esbuild: 0.15.12
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 3.1.4
+      resolve-from: 5.0.0
+      rollup: 3.3.0
+      source-map: 0.8.0-beta.0
+      sucrase: 3.28.0
+      tree-kill: 1.2.2
+      typescript: 4.8.4
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
   /tsutils/3.21.0_typescript@4.8.4:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
@@ -5035,6 +5290,24 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
+  /vite-plugin-solid/2.4.0_solid-js@1.6.1+vite@3.2.3:
+    resolution: {integrity: sha512-Rr+t2sr9TWIvH16yzBZzx6O9YSpYAvcwKUMPqbi/4iU3mRumXQ4O10i1XGtQIynC7U3XwJsMzAJigDFGbiJBiw==}
+    peerDependencies:
+      solid-js: ^1.3.17
+      vite: ^3.0.0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/preset-typescript': 7.18.6_@babel+core@7.19.6
+      babel-preset-solid: 1.6.2_@babel+core@7.19.6
+      merge-anything: 5.1.1
+      solid-js: 1.6.1
+      solid-refresh: 0.4.1_solid-js@1.6.1
+      vite: 3.2.3
+      vitefu: 0.1.1_vite@3.2.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /vite/3.2.3:
     resolution: {integrity: sha512-h8jl1TZ76eGs3o2dIBSsvXDLb1m/Ec1iej8ZMdz+PsaFUsftZeWe2CZOI3qogEsMNaywc17gu0q6cQDzh/weCQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -5100,6 +5373,17 @@ packages:
       rollup: 2.79.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /vitefu/0.1.1_vite@3.2.3:
+    resolution: {integrity: sha512-HClD14fjMJ+NQgXBqT3dC3RdO/+Chayil+cCPYZKY3kT+KcJomKzrdgzfCHJkIL2L0OAY+VPvrSW615iPtc7ag==}
+    peerDependencies:
+      vite: ^3.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      vite: 3.2.3
     dev: true
 
   /vitest/0.25.2_jsdom@20.0.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1366,6 +1366,25 @@ packages:
       - supports-color
     dev: true
 
+  /@vitest/coverage-c8/0.25.1_jsdom@20.0.2:
+    resolution: {integrity: sha512-gpl5QNaNeIN0mfRiosCqBFoZcizb5GA458TDnOQXkGDc4kklazxn70u9evGfV62wiiAUfGGebgRhxlBkAa6m6g==}
+    dependencies:
+      c8: 7.12.0
+      vitest: 0.25.1_jsdom@20.0.2
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /@vitest/coverage-c8/0.25.2_jsdom@20.0.2:
     resolution: {integrity: sha512-qKsiUJh3bjbB5Q229CbxEWCqiDBwvIrcZ9OOuQdMEC0pce3/LlTUK3+K3hd7WqAYEbbiqXfC5MVMKHZkV82PgA==}
     dependencies:
@@ -5384,6 +5403,52 @@ packages:
         optional: true
     dependencies:
       vite: 3.2.3
+    dev: true
+
+  /vitest/0.25.1_jsdom@20.0.2:
+    resolution: {integrity: sha512-eH74h6MkuEgsqR4mAQZeMK9O0PROiKY+i+1GMz/fBi5A3L2ml5U7JQs7LfPU7+uWUziZyLHagl+rkyfR8SLhlA==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.3
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.11.9
+      acorn: 8.8.1
+      acorn-walk: 8.2.0
+      chai: 4.3.6
+      debug: 4.3.4
+      jsdom: 20.0.2
+      local-pkg: 0.4.2
+      source-map: 0.6.1
+      strip-literal: 0.4.2
+      tinybench: 2.3.1
+      tinypool: 0.3.0
+      tinyspy: 1.0.2
+      vite: 3.2.3_@types+node@18.11.9
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vitest/0.25.2_jsdom@20.0.2:


### PR DESCRIPTION
I ported the polymorphic factory to solid and used the built in `Dynamic` component.
Seems to work as good as with React 🎉  

> Event types in callbacks e.g. `onClick` still have the old component type