### PR TITLE
feat(react): add support for ref typings

### DIFF
--- a/.changeset/slow-students-peel.md
+++ b/.changeset/slow-students-peel.md
@@ -1,0 +1,15 @@
+---
+'@polymorphic-factory/react': minor
+---
+
+Fixed an issue where the factory options type `polymorphicFactory<P, Options>()` did not propagate
+to the factory function `poly("div", options)`. **This is possibly a breaking change for TypeScript
+users.**
+
+```tsx
+type AdditionalProps = Record<never, never>
+type Options = { 'data-custom-option': string }
+
+const poly = polymorphicFactory<AdditionalProps, Options>()
+const CustomDiv = poly('div', { 'data-custom-option': 'hello' })
+```

--- a/.changeset/spotty-geckos-cheer.md
+++ b/.changeset/spotty-geckos-cheer.md
@@ -1,0 +1,23 @@
+---
+'@polymorphic-factory/react': minor
+---
+
+- When using the `as` prop, the `ref` will now be typed accordingly. **This is possibly a breaking
+  change for TypeScript users.**
+
+  ```tsx
+  const ref = React.useRef<HTMLAnchorElement>(null)
+  return <poly.button as="a" ref={ref} />
+  ```
+
+- Removed the member `defaultProps` from the type `ComponentWithAs` to support React 18.3.0. **This
+  is possibly a breaking change for TypeScript users.**
+
+- The `polymorphicFactory` and the type `HTMLPolymorphicComponents` now accept an optional generic
+  to specify additional props.
+
+  ```tsx
+  const poly = polymorphicFactory<{ background: 'red' | 'blue' }>()
+
+  const App = () => <poly.div background="red" />
+  ```

--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ const App = () => (
 )
 ```
 
-> **Known drawbacks for the type definitions:**
->
-> Event handlers are not typed correctly when using the `as` prop.
->
-> This is a deliberate decision to keep the usage as simple as possible.
-
 This monorepo uses [pnpm](https://pnpm.io) as a package manager. It includes the following packages:
 
 ## Packages
@@ -72,7 +66,8 @@ pnpm run solid build
 
 ### Versioning
 
-This repository uses [changesets](https://github.com/changesets/changesets) to version and publish the packages.
+This repository uses [changesets](https://github.com/changesets/changesets) to version and publish
+the packages.
 
 To create a semver bump, create a changeset with a summary of the changes made:
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -12,12 +12,6 @@ Create polymorphic React components with a customizable `styled` function.
 
 A polymorphic component is a component that can be rendered with a different element.
 
-> **Known drawbacks for the type definitions:**
->
-> Event handlers are not typed correctly when using the `as` prop.
->
-> This is a deliberate decision to keep the usage as simple as possible.
-
 ## Installation
 
 ```bash
@@ -43,6 +37,39 @@ Import the polymorphic factory and create your element factory.
 ```ts
 import { polymorphicFactory } from '@polymorphic-factory/react'
 const poly = polymorphicFactory()
+```
+
+### Inline
+
+Use the element factory to create elements inline. Every JSX element is supported `div`, `main`,
+`aside`, etc.
+
+```tsx
+<>
+  <poly.div />
+  <poly.main>
+    <poly.section>
+      <poly.div as="p">This is rendered as a p element</poly.div>
+    </poly.section>
+  </poly.main>
+</>
+```
+
+### Refs
+
+You can also pass a `ref` to the element factory. This is useful when you want to access the DOM
+element.
+
+```tsx
+const ref = React.useRef<HTMLDivElement>(null)
+return <poly.div ref={ref} />
+```
+
+When using the `as` prop, the `ref` will be typed accordingly as well.
+
+```tsx
+const ref = React.useRef<HTMLAnchorElement>(null)
+return <poly.button as="a" ref={ref} />
 ```
 
 ### Custom `styled` function
@@ -72,22 +99,6 @@ const App = () => {
 }
 ```
 
-### Inline
-
-Use the element factory to create elements inline.
-Every JSX element is supported `div`, `main`, `aside`, etc.
-
-```tsx
-<>
-  <poly.div />
-  <poly.main>
-    <poly.section>
-      <poly.div as="p">This is rendered as a p element</poly.div>
-    </poly.section>
-  </poly.main>
-</>
-```
-
 ### Factory
 
 Use the factory to wrap custom components.
@@ -105,6 +116,15 @@ It still supports the `as` prop, which would replace the `OriginalComponent`.
 ```tsx
 <MyComponent as="div" />
 // renders <div />
+```
+
+If you want to allow a set of default props for each component, you can pass it as the first generic
+to `polymorphicFactory`.
+
+```tsx
+const poly = polymorphicFactory<{ background: 'red' | 'blue' }>()
+
+const App = () => <poly.div background="red" />
 ```
 
 ## Types

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -59,6 +59,7 @@
     "vitest": "0.26.2"
   },
   "peerDependencies": {
-    "react": ">=16.8 || >=17 || >18"
+    "react": ">=16.8 || >=17 || >18",
+    "@types/react": "*"
   }
 }

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -25,15 +25,9 @@ export type PropsOf<Component extends ElementType> = JSX.LibraryManagedAttribute
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  */
-export type Assign<
-  Target extends Record<string, unknown>,
-  Source extends Record<string, unknown>,
-> = Omit<Target, keyof Source> & Source
+export type Assign<Target, Source> = Omit<Target, keyof Source> & Source
 
-export type ComponentWithAs<
-  Component extends ElementType,
-  Props extends Record<string, unknown> = Record<never, never>,
-> = {
+export type ComponentWithAs<Component extends ElementType, Props = Record<never, never>> = {
   <
     AsComponent extends ElementType = Component,
     Ref extends ElementRef<never> = ComponentRef<AsComponent>,
@@ -47,9 +41,8 @@ export type ComponentWithAs<
   id?: string
 }
 
-export function forwardRef<
-  Component extends ElementType,
-  Props extends Record<string, unknown> = Record<never, never>,
->(component: ForwardRefRenderFunction<never, Assign<PropsOf<Component>, Props>> & AsProp) {
+export function forwardRef<Component extends ElementType, Props = Record<never, never>>(
+  component: ForwardRefRenderFunction<never, Assign<PropsOf<Component>, Props>> & AsProp,
+) {
   return forwardRefReact(component) as unknown as ComponentWithAs<Component, Props>
 }

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -1,12 +1,8 @@
 import {
-  type Component,
   type ComponentProps,
   type ElementType,
   forwardRef as forwardRefReact,
   type ForwardRefRenderFunction,
-  type PropsWithoutRef,
-  type PropsWithRef,
-  type RefAttributes,
   type ValidationMap,
   type WeakValidationMap,
 } from 'react'
@@ -15,12 +11,7 @@ export type AsProp<AsComponent extends ElementType = ElementType> = {
   as?: AsComponent
 }
 
-// thanks to https://dev.to/nasheomirro/create-fast-type-safe-polymorphic-components-with-the-as-prop-ncn
-export type PropsOf<T extends ElementType> = PropsWithRef<
-  T extends new (props: infer P) => Component<unknown, unknown>
-    ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
-    : ComponentProps<T>
->
+export type PropsOf<T extends ElementType> = ComponentProps<T>
 
 /**
  * Assign property types from right to left.
@@ -28,7 +19,7 @@ export type PropsOf<T extends ElementType> = PropsWithRef<
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  */
-export type Assign<Target, Source> = Omit<Target, 'as' | keyof Source> & Source
+export type Assign<Target, Source> = Omit<Target, keyof Source> & Source
 
 export type ComponentWithAs<Component extends ElementType, Props = Record<never, never>> = {
   <AsComponent extends ElementType = Component>(

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -1,16 +1,16 @@
 import {
+  type ClassAttributes,
   type ComponentPropsWithoutRef,
+  type ComponentRef,
   type ElementRef,
   type ElementType,
+  forwardRef as forwardRefReact,
   type ForwardRefRenderFunction,
-  type RefAttributes,
   type ValidationMap,
   type WeakValidationMap,
-  forwardRef as forwardRefReact,
-  ComponentRef,
 } from 'react'
 
-type AsProp<AsComponent extends ElementType = ElementType> = {
+export type AsProp<AsComponent extends ElementType = ElementType> = {
   as?: AsComponent
 }
 
@@ -25,14 +25,20 @@ export type PropsOf<Component extends ElementType> = JSX.LibraryManagedAttribute
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  */
-export type Assign<Target, Source> = Omit<Target, keyof Source> & Source
+export type Assign<Target, Source> = Omit<Target, 'as' | keyof Source> & Source
 
 export type ComponentWithAs<Component extends ElementType, Props = Record<never, never>> = {
   <
     AsComponent extends ElementType = Component,
+    AsComponentProps = PropsOf<AsComponent>,
+    ComponentProps = PropsOf<Component>,
     Ref extends ElementRef<never> = ComponentRef<AsComponent>,
   >(
-    props: Assign<PropsOf<AsComponent>, Props> & RefAttributes<Ref> & AsProp<AsComponent>,
+    props: (AsComponentProps extends ComponentProps
+      ? Assign<AsComponentProps, Props>
+      : Assign<Assign<ComponentProps, AsComponentProps>, Props>) &
+      AsProp<AsComponent> &
+      ClassAttributes<Ref>,
   ): JSX.Element
 
   displayName?: string

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -1,11 +1,12 @@
 import {
-  type ClassAttributes,
-  type ComponentPropsWithoutRef,
-  type ComponentRef,
-  type ElementRef,
+  type Component,
+  type ComponentProps,
   type ElementType,
   forwardRef as forwardRefReact,
   type ForwardRefRenderFunction,
+  type PropsWithoutRef,
+  type PropsWithRef,
+  type RefAttributes,
   type ValidationMap,
   type WeakValidationMap,
 } from 'react'
@@ -14,9 +15,11 @@ export type AsProp<AsComponent extends ElementType = ElementType> = {
   as?: AsComponent
 }
 
-export type PropsOf<Component extends ElementType> = JSX.LibraryManagedAttributes<
-  Component,
-  ComponentPropsWithoutRef<Component>
+// thanks to https://dev.to/nasheomirro/create-fast-type-safe-polymorphic-components-with-the-as-prop-ncn
+export type PropsOf<T extends ElementType> = PropsWithRef<
+  T extends new (props: infer P) => Component<unknown, unknown>
+    ? PropsWithoutRef<P> & RefAttributes<InstanceType<T>>
+    : ComponentProps<T>
 >
 
 /**
@@ -28,17 +31,10 @@ export type PropsOf<Component extends ElementType> = JSX.LibraryManagedAttribute
 export type Assign<Target, Source> = Omit<Target, 'as' | keyof Source> & Source
 
 export type ComponentWithAs<Component extends ElementType, Props = Record<never, never>> = {
-  <
-    AsComponent extends ElementType = Component,
-    AsComponentProps = PropsOf<AsComponent>,
-    ComponentProps = PropsOf<Component>,
-    Ref extends ElementRef<never> = ComponentRef<AsComponent>,
-  >(
-    props: (AsComponentProps extends ComponentProps
-      ? Assign<AsComponentProps, Props>
-      : Assign<Assign<ComponentProps, AsComponentProps>, Props>) &
-      AsProp<AsComponent> &
-      ClassAttributes<Ref>,
+  <AsComponent extends ElementType = Component>(
+    props: Component extends AsComponent
+      ? Assign<PropsOf<Component>, Props & AsProp<Component>>
+      : Assign<PropsOf<AsComponent>, Props & AsProp<AsComponent>>,
   ): JSX.Element
 
   displayName?: string

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,10 @@
-export { forwardRef, type ComponentWithAs, type PropsOf, type Assign } from './forwardRef'
+export {
+  forwardRef,
+  type ComponentWithAs,
+  type AsProp,
+  type PropsOf,
+  type Assign,
+} from './forwardRef'
 export {
   polymorphicFactory,
   type HTMLPolymorphicComponents,

--- a/packages/react/src/polymorphic-factory.tsx
+++ b/packages/react/src/polymorphic-factory.tsx
@@ -3,20 +3,18 @@ import { type ComponentWithAs, forwardRef, type PropsOf } from './forwardRef'
 
 type DOMElements = keyof JSX.IntrinsicElements
 
-export type HTMLPolymorphicComponents = {
-  [Tag in DOMElements]: ComponentWithAs<Tag>
+export type HTMLPolymorphicComponents<
+  Props extends Record<string, unknown> = Record<never, never>,
+> = {
+  [Tag in DOMElements]: ComponentWithAs<Tag, Props>
 }
 
 export type HTMLPolymorphicProps<T extends ElementType> = Omit<PropsOf<T>, 'ref'> & {
   as?: ElementType
 }
 
-type PolymorphFactory = {
-  <
-    T extends ElementType,
-    P extends Record<string, unknown> = Record<never, never>,
-    Options = never,
-  >(
+type PolymorphFactory<Props extends Record<string, unknown> = Record<never, never>> = {
+  <T extends ElementType, P extends Record<string, unknown> = Props, Options = never>(
     component: T,
     option?: Options,
   ): ComponentWithAs<T, P>
@@ -48,9 +46,9 @@ interface PolyFactoryParam<
  * <poly.section as="main" /> => // renders main
  */
 export function polymorphicFactory<
-  Component extends ElementType,
-  Props extends Record<string, unknown>,
+  Props extends Record<string, unknown> = Record<never, never>,
   Options = never,
+  Component extends ElementType = ElementType,
 >({ styled = defaultStyled }: PolyFactoryParam<Component, Props, Options> = {}) {
   const cache = new Map<Component, ComponentWithAs<Component, Props>>()
 
@@ -74,5 +72,5 @@ export function polymorphicFactory<
       }
       return cache.get(asElement)
     },
-  }) as PolymorphFactory & HTMLPolymorphicComponents
+  }) as PolymorphFactory<Props> & HTMLPolymorphicComponents<Props>
 }

--- a/packages/react/src/polymorphic-factory.tsx
+++ b/packages/react/src/polymorphic-factory.tsx
@@ -13,8 +13,11 @@ export type HTMLPolymorphicProps<T extends ElementType> = Omit<PropsOf<T>, 'ref'
   as?: ElementType
 }
 
-type PolymorphFactory<Props extends Record<string, unknown> = Record<never, never>> = {
-  <T extends ElementType, P extends Record<string, unknown> = Props, Options = never>(
+type PolymorphFactory<
+  Props extends Record<string, unknown> = Record<never, never>,
+  Options = never,
+> = {
+  <T extends ElementType, P extends Record<string, unknown> = Props>(
     component: T,
     option?: Options,
   ): ComponentWithAs<T, P>
@@ -72,5 +75,5 @@ export function polymorphicFactory<
       }
       return cache.get(asElement)
     },
-  }) as PolymorphFactory<Props> & HTMLPolymorphicComponents<Props>
+  }) as PolymorphFactory<Props, Options> & HTMLPolymorphicComponents<Props>
 }

--- a/packages/react/src/polymorphic-factory.tsx
+++ b/packages/react/src/polymorphic-factory.tsx
@@ -3,9 +3,7 @@ import { type ComponentWithAs, forwardRef, type PropsOf } from './forwardRef'
 
 type DOMElements = keyof JSX.IntrinsicElements
 
-export type HTMLPolymorphicComponents<
-  Props extends Record<string, unknown> = Record<never, never>,
-> = {
+export type HTMLPolymorphicComponents<Props = Record<never, never>> = {
   [Tag in DOMElements]: ComponentWithAs<Tag, Props>
 }
 
@@ -13,14 +11,8 @@ export type HTMLPolymorphicProps<T extends ElementType> = Omit<PropsOf<T>, 'ref'
   as?: ElementType
 }
 
-type PolymorphFactory<
-  Props extends Record<string, unknown> = Record<never, never>,
-  Options = never,
-> = {
-  <T extends ElementType, P extends Record<string, unknown> = Props>(
-    component: T,
-    option?: Options,
-  ): ComponentWithAs<T, P>
+type PolymorphFactory<Props = Record<never, never>, Options = never> = {
+  <T extends ElementType, P = Props>(component: T, option?: Options): ComponentWithAs<T, P>
 }
 
 function defaultStyled(originalComponent: ElementType) {
@@ -31,11 +23,7 @@ function defaultStyled(originalComponent: ElementType) {
   })
 }
 
-interface PolyFactoryParam<
-  Component extends ElementType,
-  Props extends Record<string, unknown>,
-  Options,
-> {
+interface PolyFactoryParam<Component extends ElementType, Props, Options> {
   styled?: (component: Component, options?: Options) => ComponentWithAs<Component, Props>
 }
 
@@ -49,7 +37,7 @@ interface PolyFactoryParam<
  * <poly.section as="main" /> => // renders main
  */
 export function polymorphicFactory<
-  Props extends Record<string, unknown> = Record<never, never>,
+  Props = Record<never, never>,
   Options = never,
   Component extends ElementType = ElementType,
 >({ styled = defaultStyled }: PolyFactoryParam<Component, Props, Options> = {}) {

--- a/packages/react/test/forward-ref.test.tsx
+++ b/packages/react/test/forward-ref.test.tsx
@@ -75,6 +75,7 @@ describe('forwardRef', () => {
           className={(isActive: boolean) => (isActive ? 'active' : 'default')}
         />
         <ComponentUnderTest as={RouterLink} className="default" />
+        <ComponentUnderTest as="a" ref={createRef<HTMLAnchorElement>()} />
       </>,
     )
   })

--- a/packages/react/test/forward-ref.test.tsx
+++ b/packages/react/test/forward-ref.test.tsx
@@ -34,7 +34,25 @@ describe('forwardRef', () => {
     const onAnchorClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
       alert(e.currentTarget.nodeName)
     }
-    render(<poly.button as="a" onClick={onAnchorClick} />)
+    render(
+      <>
+        <poly.button as="a" onClick={onAnchorClick} />
+        <poly.button
+          as="a"
+          onClick={(e) => {
+            // with implicit typings
+            alert(e.currentTarget.nodeName)
+          }}
+        />
+        <poly.button
+          onClick={(e) => {
+            // with implicit typings
+            alert(e.currentTarget.nodeName)
+          }}
+        />
+        ,
+      </>,
+    )
   })
 
   it('should override duplicate prop declarations ', () => {
@@ -63,13 +81,20 @@ describe('forwardRef', () => {
 
   it('should handle custom props with highest priority', () => {
     // `size` is a prop of `React.InputHTMLAttributes<T>` and is of type `number`, we are overriding it with a string
-    const ComponentUnderTest = forwardRef<'input', { size: 'sm' | 'md' | 'lg' }>((props, ref) => {
+    const ComponentUnderTest = forwardRef<
+      'input',
+      { size: 'sm' | 'md' | 'lg'; variant: 'outline' | 'solid' }
+    >((props, ref) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { size, ...rest } = props
       return <poly.input {...rest} ref={ref} />
     })
 
-    render(<ComponentUnderTest as="input" size="sm" />)
-    render(<poly.input as={ComponentUnderTest} size="sm" />)
+    render(<ComponentUnderTest size="sm" variant="outline" disabled />)
+    render(<poly.input as={ComponentUnderTest} size="sm" variant="solid" disabled />)
+
+    // @ts-expect-error missing size and variant props
+    render(<poly.input as={ComponentUnderTest} />)
   })
 
   it('should not allow props outside the prop interface', () => {

--- a/packages/react/test/forward-ref.test.tsx
+++ b/packages/react/test/forward-ref.test.tsx
@@ -1,30 +1,84 @@
-import { createRef } from 'react'
-import type { HTMLPolymorphicProps } from '../src'
-import { polymorphicFactory, forwardRef } from '../src'
+import React, { createRef } from 'react'
+import { forwardRef, polymorphicFactory } from '../src'
 import { render } from '@testing-library/react'
 
 describe('forwardRef', () => {
   const poly = polymorphicFactory()
 
   it('should forward the ref', () => {
-    const ComponentUnderTest = forwardRef<'div', HTMLPolymorphicProps<'div'>>((props, ref) => (
-      <poly.div {...props} ref={ref} />
-    ))
+    const ComponentUnderTest = forwardRef<'div'>((props, ref) => <poly.div {...props} ref={ref} />)
 
     const ref = createRef<HTMLDivElement>()
     render(<ComponentUnderTest ref={ref} />)
     expect(ref.current).toBeInstanceOf(HTMLDivElement)
   })
 
-  it('should forward the ref with as prop', () => {
-    const ComponentUnderTest = forwardRef<'div', HTMLPolymorphicProps<'div'>>((props, ref) => (
-      <poly.div {...props} ref={ref} />
-    ))
+  it('should forward the ref with `as` prop', () => {
+    const ComponentUnderTest = forwardRef<'div'>((props, ref) => <poly.div {...props} ref={ref} />)
 
-    // known issue: with the `as` prop refs are not inherited correctly
-    // workaround:
-    const ref = createRef<HTMLDivElement & HTMLFormElement>()
+    const ref = createRef<HTMLFormElement>()
     render(<ComponentUnderTest as="form" ref={ref} />)
     expect(ref.current).toBeInstanceOf(HTMLFormElement)
+  })
+
+  it('should forward the ref with a custom component with `as` prop', () => {
+    const ComponentUnderTest = forwardRef<'div'>((props, ref) => <poly.div {...props} ref={ref} />)
+    const FormComponent = forwardRef<'form'>((props, ref) => <form {...props} ref={ref} />)
+
+    const ref = createRef<HTMLFormElement>()
+    render(<ComponentUnderTest as={FormComponent} ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLFormElement)
+  })
+
+  it('should have correct typings for event callbacks', () => {
+    const onAnchorClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      alert(e.currentTarget.nodeName)
+    }
+    render(<poly.button as="a" onClick={onAnchorClick} />)
+  })
+
+  it('should override duplicate prop declarations ', () => {
+    const ComponentUnderTest = forwardRef<'button'>((props, ref) => (
+      <poly.button {...props} ref={ref} />
+    ))
+
+    // this component has a different definition for the "className" prop than <poly.button />
+    const RouterLink = (props: { className: ((isActive: boolean) => string) | string }) => {
+      const isActive = true
+      const className =
+        typeof props.className === 'function' ? props.className(isActive) : props.className
+      return <a {...props} className={className} />
+    }
+
+    render(
+      <>
+        <ComponentUnderTest
+          as={RouterLink}
+          className={(isActive: boolean) => (isActive ? 'active' : 'default')}
+        />
+        <ComponentUnderTest as={RouterLink} className="default" />
+      </>,
+    )
+  })
+
+  it('should handle custom props with highest priority', () => {
+    // `size` is a prop of `React.InputHTMLAttributes<T>` and is of type `number`, we are overriding it with a string
+    const ComponentUnderTest = forwardRef<'input', { size: 'sm' | 'md' | 'lg' }>((props, ref) => {
+      const { size, ...rest } = props
+      return <poly.input {...rest} ref={ref} />
+    })
+
+    render(<ComponentUnderTest as="input" size="sm" />)
+    render(<poly.input as={ComponentUnderTest} size="sm" />)
+  })
+
+  it('should not allow props outside the prop interface', () => {
+    const ComponentUnderTest = forwardRef<'input'>((props, ref) => <input {...props} ref={ref} />)
+
+    // @ts-expect-error nonExistentProp is not a valid prop
+    render(<ComponentUnderTest nonExistentProp="should error" />)
+
+    // @ts-expect-error nonExistentProp is not a valid prop
+    render(<poly.input nonExistentProp="should error" />)
   })
 })

--- a/packages/react/test/polymorphic-factory.test.tsx
+++ b/packages/react/test/polymorphic-factory.test.tsx
@@ -84,8 +84,25 @@ describe('Polymorphic Factory', () => {
 
     it('should expect required props', () => {
       // @ts-expect-error Property 'customProp' is missing
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const _unused = <CustomComponent />
+      render(<CustomComponent />)
+    })
+  })
+
+  describe('with custom props', () => {
+    const poly = polymorphicFactory<{ customProp: 'a' | 'b' | 'c' }>()
+
+    it('should allow custom props', () => {
+      render(<poly.div customProp="a" />)
+    })
+
+    it('should expect required props', () => {
+      // @ts-expect-error Property 'customProp' is missing
+      render(<poly.div />)
+    })
+
+    it('should expect required props with `as` prop', () => {
+      // @ts-expect-error Property 'customProp' is missing
+      render(<poly.div as="input" />)
     })
   })
 })

--- a/packages/react/test/polymorphic-factory.test.tsx
+++ b/packages/react/test/polymorphic-factory.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import { type HTMLPolymorphicProps, polymorphicFactory } from '../src'
+import { type ComponentWithAs, type HTMLPolymorphicProps, polymorphicFactory } from '../src'
 
 describe('Polymorphic Factory', () => {
   describe('with default styled function', () => {
@@ -85,6 +85,39 @@ describe('Polymorphic Factory', () => {
     it('should expect required props', () => {
       // @ts-expect-error Property 'customProp' is missing
       render(<CustomComponent />)
+    })
+
+    it('should have correct types for the poly factory', () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const Comp = (_props: Record<never, never>) => null
+      type CompWithRequiredProps = { thisIsARequiredProp: boolean }
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const CompWithRequired = (_props: CompWithRequiredProps) => null
+
+      render(<poly.div />)
+      render(<poly.div as="img" src="/this-is-the-way.webp" />)
+      render(<poly.div as={Comp} />)
+      render(<poly.div as={CompWithRequired} thisIsARequiredProp />)
+    })
+
+    it('should have correct types for the ComponentWithAs with additional props', () => {
+      const AdditionalPropComp: ComponentWithAs<'div', { additionalProp: boolean }> = ({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        additionalProp,
+        ...restProps
+      }) => <poly.div {...restProps} />
+
+      render(<AdditionalPropComp additionalProp />)
+    })
+
+    it('should have correct types for the ComponentWithAs with optional additional props', () => {
+      const OptionalAdditionalPropComp: ComponentWithAs<'div', { additionalProp?: boolean }> = ({
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        additionalProp,
+        ...restProps
+      }) => <poly.div {...restProps} />
+
+      render(<OptionalAdditionalPropComp />)
     })
   })
 

--- a/packages/react/test/polymorphic-factory.test.tsx
+++ b/packages/react/test/polymorphic-factory.test.tsx
@@ -26,7 +26,7 @@ describe('Polymorphic Factory', () => {
   })
 
   describe('with custom styled function', () => {
-    const customPoly = polymorphicFactory({
+    const customPoly = polymorphicFactory<Record<never, never>, { customOption?: string }>({
       styled: (component, options) => (props) => {
         const Component = props.as || component
         return <Component data-custom-styled data-options={JSON.stringify(options)} {...props} />


### PR DESCRIPTION
- When using the `as` prop, the `ref` will now be typed accordingly. **This is possibly a breaking
  change for TypeScript users.**

  ```tsx
  const ref = React.useRef<HTMLAnchorElement>(null)
  return <poly.button as="a" ref={ref} />
  ```

- Removed the member `defaultProps` from the type `ComponentWithAs` to support React 18.3.0. **This
  is possibly a breaking change for TypeScript users.**

- The `polymorphicFactory` and the type `HTMLPolymorphicComponents` now accept an optional generic
  to specify additional props.

  ```tsx
  const poly = polymorphicFactory<{ background: 'red' | 'blue' }>()
  const App = () => <poly.div background="red" />
  ```

- Fixed an issue where the factory options type `polymorphicFactory<P, Options>()` did not propagate
  to the factory function `poly("div", options)`. **This is possibly a breaking change for TypeScript
  users.**

  ```tsx
  type AdditionalProps = Record<never, never>
  type Options = { 'data-custom-option': string }
  const poly = polymorphicFactory<AdditionalProps, Options>()
  const CustomDiv = poly('div', { 'data-custom-option': 'hello' })
  ```