### PR TITLE
feat: add ref typings for react, preact and solid

### DIFF
--- a/.changeset/dry-badgers-turn.md
+++ b/.changeset/dry-badgers-turn.md
@@ -1,0 +1,7 @@
+---
+'@polymorphic-factory/react': minor
+---
+
+Removed the member `defaultProps` from the type `ComponentWithAs` to support React 18.3.0. 
+
+**This is possibly a breaking change for TypeScript users.**

--- a/.changeset/eleven-cameras-bake.md
+++ b/.changeset/eleven-cameras-bake.md
@@ -1,0 +1,12 @@
+---
+'@polymorphic-factory/react': minor
+---
+
+When using the `as` prop, the `ref` will now be typed accordingly. 
+
+**This is possibly a breaking change for TypeScript users.**
+
+```tsx
+const ref = useRef<HTMLAnchorElement>(null)
+return <poly.button as="a" ref={ref} />
+```

--- a/.changeset/gold-seahorses-move.md
+++ b/.changeset/gold-seahorses-move.md
@@ -1,0 +1,12 @@
+---
+'@polymorphic-factory/solid': minor
+---
+
+When using the `as` prop, the `ref` will now be typed accordingly.
+
+**This is possibly a breaking change for TypeScript users.**
+
+```tsx
+let ref: HTMLAnchorElement = undefined
+return <poly.button as="a" ref={ref} />
+```

--- a/.changeset/good-rabbits-relax.md
+++ b/.changeset/good-rabbits-relax.md
@@ -1,0 +1,12 @@
+---
+'@polymorphic-factory/preact': minor
+---
+
+When using the `as` prop, the `ref` will now be typed accordingly.
+
+**This is possibly a breaking change for TypeScript users.**
+
+```tsx
+const ref = useRef<HTMLAnchorElement>(null)
+return <poly.button as="a" ref={ref} />
+```

--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ const App = () => (
 )
 ```
 
-> **Known drawbacks for the type definitions:**
->
-> Event handlers are not typed correctly when using the `as` prop.
->
-> This is a deliberate decision to keep the usage as simple as possible.
-
 This monorepo uses [pnpm](https://pnpm.io) as a package manager. It includes the following packages:
 
 ## Packages

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -10,13 +10,9 @@
 
 Create polymorphic Preact components with a customizable `styled` function.
 
-A polymorphic component is a component that can be rendered with a different element.
-
-> **Known drawbacks for the type definitions:**
->
-> Event handlers are not typed correctly when using the `as` prop.
->
-> This is a deliberate decision to keep the usage as simple as possible.
+A polymorphic component is a component that can be rendered with a different element. This is useful
+for component libraries that want to provide a consistent API for their users and want to allow them
+to customize the underlying element.
 
 ## Installation
 
@@ -105,6 +101,16 @@ It still supports the `as` prop, which would replace the `OriginalComponent`.
 ```tsx
 <MyComponent as="div" />
 // renders <div />
+```
+## Refs
+
+You can use `ref` on the component, and it will have the correct typings.
+
+```tsx
+const App = () => {
+  const ref = useRef<HTMLAnchorElement>(null)
+  return <poly.button as="a" ref={ref} />
+}
 ```
 
 ## Types

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -48,6 +48,7 @@
     "@types/testing-library__jest-dom": "5.14.5",
     "@preact/preset-vite": "2.5.0",
     "@vitest/coverage-c8": "0.29.8",
+    "csstype": "3.1.1",
     "clean-package": "2.2.0",
     "jsdom": "21.1.1",
     "preact": "10.13.2",

--- a/packages/preact/src/forwardRef.tsx
+++ b/packages/preact/src/forwardRef.tsx
@@ -10,40 +10,62 @@ export type PropsOf<T extends ElementType> = ComponentProps<T> & {
   as?: ElementType
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never
+
 /**
  * Assign property types from right to left.
  * Think `Object.assign` for types.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  */
-export type Assign<Target, Source> = Omit<Target, keyof Source> & Source
-
-export type OmitCommonProps<
-  Target,
-  OmitAdditionalProps extends string | number | symbol = never,
-> = Omit<Target, 'transition' | 'as' | 'color' | OmitAdditionalProps>
-
-type AssignCommon<
-  SourceProps extends Record<string, unknown> = Record<never, never>,
-  OverrideProps extends Record<string, unknown> = Record<never, never>,
-> = Assign<OmitCommonProps<SourceProps>, OverrideProps>
+export type Assign<A, B> = DistributiveOmit<A, keyof B> & B
 
 type MergeWithAs<
-  ComponentProps extends Record<string, unknown>,
-  AsProps extends Record<string, unknown>,
-  AdditionalProps extends Record<string, unknown> = Record<never, never>,
-  AsComponent extends ElementType = ElementType,
-> = AssignCommon<ComponentProps, AdditionalProps> &
-  AssignCommon<AsProps, AdditionalProps> & {
-    as?: AsComponent
-  }
+  Default extends ElementType,
+  Component extends ElementType,
+  PermanentProps extends Record<never, never>,
+  DefaultProps extends Record<never, never>,
+  ComponentProps extends Record<never, never>,
+> =
+  /**
+   * The following code is copied from the library react-polymorphed by nasheomirro.
+   * Thank your for creating this TypeScript gold!
+   *
+   * doing this makes sure typescript infers events. Without the
+   * extends check typescript won't do an additional inference phase,
+   * but somehow we can trick typescript into doing so. Note that the check needs to be relating
+   * to the generic for this to work.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any extends Component
+    ? /**
+       * Merge<ComponentProps, OwnProps & { as?: Component }> looks sufficient,
+       * but typescript won't be able to infer events on components that haven't
+       * explicitly provided a value for the As generic or haven't provided an `as` prop.
+       * We could do the same trick again like the above but discriminating unions should be
+       * enough as we don't have to compute the value for the default.
+       *
+       * Also note that Merging here is needed not just for the purpose of
+       * overriding props but also because somehow it is needed to get the props correctly,
+       * Merge does clone the first object so that might have something to do with it.
+       */
+      | Assign<DefaultProps, PermanentProps & { as?: Default }>
+        | Assign<ComponentProps, PermanentProps & { as?: Component }>
+    : never
 
 export type ComponentWithAs<
   Component extends ElementType,
-  Props extends Record<string, unknown> = Record<never, never>,
+  Props extends Record<never, never> = Record<never, never>,
 > = {
   <AsComponent extends ElementType = Component>(
-    props: MergeWithAs<ComponentProps<Component>, ComponentProps<AsComponent>, Props, AsComponent>,
+    props: MergeWithAs<
+      Component,
+      AsComponent,
+      Props,
+      ComponentProps<Component>,
+      ComponentProps<AsComponent>
+    >,
   ): JSX.Element
 
   displayName?: string
@@ -52,15 +74,8 @@ export type ComponentWithAs<
   id?: string
 }
 
-export function forwardRef<
-  Component extends ElementType,
-  Props extends Record<string, unknown> = Record<never, never>,
->(
-  component: ForwardFn<
-    AssignCommon<PropsOf<Component>, Props> & {
-      as?: ElementType
-    }
-  >,
+export function forwardRef<Component extends ElementType, Props extends object = object>(
+  component: ForwardFn<Props & { as?: ElementType }>,
 ) {
   return forwardRefPreact(component) as unknown as ComponentWithAs<Component, Props>
 }

--- a/packages/preact/src/polymorphic-factory.tsx
+++ b/packages/preact/src/polymorphic-factory.tsx
@@ -3,9 +3,7 @@ import type { JSX } from 'preact'
 
 type DOMElements = keyof JSX.IntrinsicElements
 
-export type HTMLPolymorphicComponents<
-  Props extends Record<string, unknown> = Record<never, never>,
-> = {
+export type HTMLPolymorphicComponents<Props extends Record<never, never> = Record<never, never>> = {
   [Tag in DOMElements]: ComponentWithAs<Tag, Props>
 }
 
@@ -14,10 +12,10 @@ export type HTMLPolymorphicProps<T extends ElementType> = Omit<PropsOf<T>, 'ref'
 }
 
 type PolymorphFactory<
-  Props extends Record<string, unknown> = Record<never, never>,
+  Props extends Record<never, never> = Record<never, never>,
   Options = never,
 > = {
-  <T extends ElementType, P extends Record<string, unknown> = Props>(
+  <T extends ElementType, P extends Record<never, never> = Props>(
     component: T,
     option?: Options,
   ): ComponentWithAs<T, P>
@@ -33,7 +31,7 @@ function defaultStyled(originalComponent: ElementType) {
 
 interface PolyFactoryParam<
   Component extends ElementType,
-  Props extends Record<string, unknown>,
+  Props extends Record<never, never>,
   Options,
 > {
   styled?: (component: Component, options?: Options) => ComponentWithAs<Component, Props>

--- a/packages/preact/test/forward-ref.test.tsx
+++ b/packages/preact/test/forward-ref.test.tsx
@@ -21,9 +21,7 @@ describe('forwardRef', () => {
       <poly.div {...props} ref={ref} />
     ))
 
-    // known issue: with the `as` prop refs are not inherited correctly
-    // workaround:
-    const ref = createRef<HTMLDivElement & HTMLFormElement>()
+    const ref = createRef<HTMLFormElement>()
     render(<ComponentUnderTest as="form" ref={ref} />)
     expect(ref.current).toBeInstanceOf(HTMLFormElement)
   })

--- a/packages/preact/test/polymorphic-factory.test.tsx
+++ b/packages/preact/test/polymorphic-factory.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/preact'
+import { createRef } from 'preact'
 import { type HTMLPolymorphicProps, polymorphicFactory } from '../src'
+import type { Properties } from 'csstype'
 
 describe('Polymorphic Factory', () => {
   describe('with default styled function', () => {
@@ -17,6 +19,17 @@ describe('Polymorphic Factory', () => {
       expect(element.nodeName).toBe('MAIN')
     })
 
+    it('should have the correct ref typings when using the as prop', () => {
+      const ref = createRef<HTMLAnchorElement>()
+
+      // @ts-expect-error - button ref is not an anchor ref
+      render(<poly.button ref={ref} />)
+
+      render(<poly.button data-testid="poly" as="a" ref={ref} />)
+      const element = screen.getByTestId('poly')
+      expect(element.nodeName).toBe('A')
+    })
+
     it('should render an element with the factory', () => {
       const Aside = poly('aside')
       render(<Aside data-testid="poly" />)
@@ -26,7 +39,7 @@ describe('Polymorphic Factory', () => {
   })
 
   describe('with custom styled function', () => {
-    const customPoly = polymorphicFactory<Record<never, never>, { customOption: string }>({
+    const customPoly = polymorphicFactory<Record<never, never>, { customOption?: string }>({
       styled: (component, options) => (props) => {
         const Component = props.as || component
         return <Component data-custom-styled data-options={JSON.stringify(options)} {...props} />
@@ -85,6 +98,11 @@ describe('Polymorphic Factory', () => {
     it('should expect required props', () => {
       // @ts-expect-error Property 'customProp' is missing
       render(<CustomComponent />)
+    })
+
+    it('should handle many additional props', () => {
+      const poly = polymorphicFactory<Properties & { 'data-some-other': 'prop' }>()
+      render(<poly.div display="flex" data-some-other="prop" />)
     })
   })
 })

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -10,13 +10,9 @@
 
 Create polymorphic React components with a customizable `styled` function.
 
-A polymorphic component is a component that can be rendered with a different element.
-
-> **Known drawbacks for the type definitions:**
->
-> Event handlers are not typed correctly when using the `as` prop.
->
-> This is a deliberate decision to keep the usage as simple as possible.
+A polymorphic component is a component that can be rendered with a different element. This is useful
+for component libraries that want to provide a consistent API for their users and want to allow them
+to customize the underlying element.
 
 ## Installation
 
@@ -105,6 +101,17 @@ It still supports the `as` prop, which would replace the `OriginalComponent`.
 ```tsx
 <MyComponent as="div" />
 // renders <div />
+```
+
+## Refs
+
+You can use `ref` on the component, and it will have the correct typings.
+
+```tsx
+const App = () => {
+  const ref = React.useRef<HTMLAnchorElement>(null)
+  return <poly.button as="a" ref={ref} />
+}
 ```
 
 ## Types

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,6 +51,7 @@
     "@vitejs/plugin-react": "3.1.0",
     "@vitest/coverage-c8": "0.29.8",
     "clean-package": "2.2.0",
+    "csstype": "3.1.1",
     "jsdom": "21.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -61,7 +61,7 @@ type MergeWithAs<
 
 export type ComponentWithAs<
   Component extends ElementType,
-  Props extends Record<string, unknown> = Record<never, never>,
+  Props extends Record<never, never> = Record<never, never>,
 > = {
   <AsComponent extends ElementType = Component>(
     props: MergeWithAs<
@@ -81,7 +81,7 @@ export type ComponentWithAs<
 
 export function forwardRef<
   Component extends ElementType,
-  Props extends Record<string, unknown> = Record<never, never>,
+  Props extends Record<never, never> = Record<never, never>,
 >(component: ForwardRefRenderFunction<never, Props & { as?: ElementType }>) {
   return forwardRefReact(component) as unknown as ComponentWithAs<Component, Props>
 }

--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -2,10 +2,10 @@ import {
   type ComponentProps,
   type ComponentPropsWithoutRef,
   type ElementType,
+  forwardRef as forwardRefReact,
   type ForwardRefRenderFunction,
   type ValidationMap,
   type WeakValidationMap,
-  forwardRef as forwardRefReact,
 } from 'react'
 
 /**
@@ -15,59 +15,73 @@ export type PropsOf<T extends ElementType> = ComponentPropsWithoutRef<T> & {
   as?: ElementType
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DistributiveOmit<T, K extends keyof any> = T extends any ? Omit<T, K> : never
+
 /**
  * Assign property types from right to left.
  * Think `Object.assign` for types.
  *
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
  */
-export type Assign<Target, Source> = Omit<Target, keyof Source> & Source
-
-export type OmitCommonProps<
-  Target,
-  OmitAdditionalProps extends string | number | symbol = never,
-> = Omit<Target, 'transition' | 'as' | 'color' | OmitAdditionalProps>
-
-type AssignCommon<
-  SourceProps extends Record<string, unknown> = Record<never, never>,
-  OverrideProps extends Record<string, unknown> = Record<never, never>,
-> = Assign<OmitCommonProps<SourceProps>, OverrideProps>
+export type Assign<A, B> = DistributiveOmit<A, keyof B> & B
 
 type MergeWithAs<
-  ComponentProps extends Record<string, unknown>,
-  AsProps extends Record<string, unknown>,
-  AdditionalProps extends Record<string, unknown> = Record<never, never>,
-  AsComponent extends ElementType = ElementType,
-> = AssignCommon<ComponentProps, AdditionalProps> &
-  AssignCommon<AsProps, AdditionalProps> & {
-    as?: AsComponent
-  }
+  Default extends ElementType,
+  Component extends ElementType,
+  PermanentProps extends Record<never, never>,
+  DefaultProps extends Record<never, never>,
+  ComponentProps extends Record<never, never>,
+> =
+  /**
+   * The following code is copied from the library react-polymorphed by nasheomirro.
+   * Thank your for creating this TypeScript gold!
+   *
+   * doing this makes sure typescript infers events. Without the
+   * extends check typescript won't do an additional inference phase,
+   * but somehow we can trick typescript into doing so. Note that the check needs to be relating
+   * to the generic for this to work.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any extends Component
+    ? /**
+       * Merge<ComponentProps, OwnProps & { as?: Component }> looks sufficient,
+       * but typescript won't be able to infer events on components that haven't
+       * explicitly provided a value for the As generic or haven't provided an `as` prop.
+       * We could do the same trick again like the above but discriminating unions should be
+       * enough as we don't have to compute the value for the default.
+       *
+       * Also note that Merging here is needed not just for the purpose of
+       * overriding props but also because somehow it is needed to get the props correctly,
+       * Merge does clone the first object so that might have something to do with it.
+       */
+      | Assign<DefaultProps, PermanentProps & { as?: Default }>
+        | Assign<ComponentProps, PermanentProps & { as?: Component }>
+    : never
 
 export type ComponentWithAs<
   Component extends ElementType,
   Props extends Record<string, unknown> = Record<never, never>,
 > = {
   <AsComponent extends ElementType = Component>(
-    props: MergeWithAs<ComponentProps<Component>, ComponentProps<AsComponent>, Props, AsComponent>,
+    props: MergeWithAs<
+      Component,
+      AsComponent,
+      Props,
+      ComponentProps<Component>,
+      ComponentProps<AsComponent>
+    >,
   ): JSX.Element
 
   displayName?: string
   propTypes?: WeakValidationMap<unknown>
   contextTypes?: ValidationMap<unknown>
-  defaultProps?: Partial<unknown>
   id?: string
 }
 
 export function forwardRef<
   Component extends ElementType,
   Props extends Record<string, unknown> = Record<never, never>,
->(
-  component: ForwardRefRenderFunction<
-    never,
-    AssignCommon<PropsOf<Component>, Props> & {
-      as?: ElementType
-    }
-  >,
-) {
+>(component: ForwardRefRenderFunction<never, Props & { as?: ElementType }>) {
   return forwardRefReact(component) as unknown as ComponentWithAs<Component, Props>
 }

--- a/packages/react/src/polymorphic-factory.tsx
+++ b/packages/react/src/polymorphic-factory.tsx
@@ -3,9 +3,7 @@ import { type ComponentWithAs, forwardRef, type PropsOf } from './forwardRef'
 
 type DOMElements = keyof JSX.IntrinsicElements
 
-export type HTMLPolymorphicComponents<
-  Props extends Record<string, unknown> = Record<never, never>,
-> = {
+export type HTMLPolymorphicComponents<Props extends Record<never, never> = Record<never, never>> = {
   [Tag in DOMElements]: ComponentWithAs<Tag, Props>
 }
 
@@ -14,10 +12,10 @@ export type HTMLPolymorphicProps<T extends ElementType> = Omit<PropsOf<T>, 'ref'
 }
 
 type PolymorphFactory<
-  Props extends Record<string, unknown> = Record<never, never>,
+  Props extends Record<never, never> = Record<never, never>,
   Options = never,
 > = {
-  <T extends ElementType, P extends Record<string, unknown> = Props>(
+  <T extends ElementType, P extends Record<never, never> = Props>(
     component: T,
     option?: Options,
   ): ComponentWithAs<T, P>
@@ -33,7 +31,7 @@ function defaultStyled(originalComponent: ElementType) {
 
 interface PolyFactoryParam<
   Component extends ElementType,
-  Props extends Record<string, unknown>,
+  Props extends Record<never, never>,
   Options,
 > {
   styled?: (component: Component, options?: Options) => ComponentWithAs<Component, Props>

--- a/packages/react/test/forward-ref.test.tsx
+++ b/packages/react/test/forward-ref.test.tsx
@@ -21,9 +21,7 @@ describe('forwardRef', () => {
       <poly.div {...props} ref={ref} />
     ))
 
-    // known issue: with the `as` prop refs are not inherited correctly
-    // workaround:
-    const ref = createRef<HTMLDivElement & HTMLFormElement>()
+    const ref = createRef<HTMLFormElement>()
     render(<ComponentUnderTest as="form" ref={ref} />)
     expect(ref.current).toBeInstanceOf(HTMLFormElement)
   })

--- a/packages/react/test/polymorphic-factory.test.tsx
+++ b/packages/react/test/polymorphic-factory.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { HTMLPolymorphicProps, polymorphicFactory } from '../src'
+import type { Properties } from 'csstype'
 
 describe('Polymorphic Factory', () => {
   describe('with default styled function', () => {
@@ -85,6 +86,11 @@ describe('Polymorphic Factory', () => {
     it('should expect required props', () => {
       // @ts-expect-error Property 'customProp' is missing
       render(<CustomComponent />)
+    })
+
+    it('should handle many additional props', () => {
+      const poly = polymorphicFactory<Properties & { 'data-some-other': 'prop' }>()
+      render(<poly.div display="flex" data-some-other="prop" />)
     })
   })
 })

--- a/packages/react/test/polymorphic-factory.test.tsx
+++ b/packages/react/test/polymorphic-factory.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { HTMLPolymorphicProps, polymorphicFactory } from '../src'
 import type { Properties } from 'csstype'
+import { createRef } from 'react'
 
 describe('Polymorphic Factory', () => {
   describe('with default styled function', () => {
@@ -16,6 +17,17 @@ describe('Polymorphic Factory', () => {
       render(<poly.div data-testid="poly" as="main" />)
       const element = screen.getByTestId('poly')
       expect(element.nodeName).toBe('MAIN')
+    })
+
+    it('should have the correct ref typings when using the as prop', () => {
+      const ref = createRef<HTMLAnchorElement>()
+
+      // @ts-expect-error - button ref is not an anchor ref
+      render(<poly.button ref={ref} />)
+
+      render(<poly.button data-testid="poly" as="a" ref={ref} />)
+      const element = screen.getByTestId('poly')
+      expect(element.nodeName).toBe('A')
     })
 
     it('should render an element with the factory', () => {

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -10,13 +10,10 @@
 
 Create polymorphic SolidJS components with a customizable `styled` function.
 
-A polymorphic component is a component that can be rendered with a different element.
+A polymorphic component is a component that can be rendered with a different element. This is useful
+for component libraries that want to provide a consistent API for their users and want to allow them
+to customize the underlying element.
 
-> **Known drawbacks for the type definitions:**
->
-> Event handlers are not typed correctly when using the `as` prop.
->
-> This is a deliberate decision to keep the usage as simple as possible.
 
 ## Installation
 

--- a/packages/vue/src/polymorphic-factory.tsx
+++ b/packages/vue/src/polymorphic-factory.tsx
@@ -2,6 +2,7 @@ import {
   type AllowedComponentProps,
   type ComponentCustomProps,
   type DefineComponent,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   h,
   defineComponent,
   type ExtractPropTypes,

--- a/packages/vue/src/use-v-model.ts
+++ b/packages/vue/src/use-v-model.ts
@@ -4,12 +4,14 @@ const formElements = ['input', 'select', 'textarea', 'fieldset', 'datalist', 'op
 
 export const useVModel = (
   elementTag: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   modelValue: any,
   emit: CallableFunction,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   attrs: any,
 ) => {
   let vmodelAttrs = {}
-  const handleMultipleCheckbox = (value: any) => {
+  const handleMultipleCheckbox = (value: unknown) => {
     const currentModelValue = [...modelValue]
     if (currentModelValue.includes(value)) {
       currentModelValue.splice(currentModelValue.indexOf(value), 1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
         version: 2.8.7
       tsup:
         specifier: ^6.3.0
-        version: 6.6.3(ts-node@10.9.1)(typescript@4.9.5)
+        version: 6.6.3(typescript@4.9.5)
       turbo:
         specifier: 1.8.8
         version: 1.8.8
@@ -51,7 +51,7 @@ importers:
     devDependencies:
       '@preact/preset-vite':
         specifier: 2.5.0
-        version: 2.5.0(@babel/core@7.21.0)(preact@10.13.2)(vite@4.2.1)
+        version: 2.5.0(preact@10.13.2)(vite@4.2.1)
       '@testing-library/jest-dom':
         specifier: 5.16.5
         version: 5.16.5
@@ -78,7 +78,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: 4.2.1
-        version: 4.2.1(@types/node@18.15.11)
+        version: 4.2.1
       vitest:
         specifier: 0.29.8
         version: 0.29.8(jsdom@21.1.1)
@@ -109,6 +109,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
+      csstype:
+        specifier: 3.1.1
+        version: 3.1.1
       jsdom:
         specifier: 21.1.1
         version: 21.1.1
@@ -123,7 +126,7 @@ importers:
         version: 4.9.5
       vite:
         specifier: 4.2.1
-        version: 4.2.1(@types/node@18.15.11)
+        version: 4.2.1
       vitest:
         specifier: 0.29.8
         version: 0.29.8(jsdom@21.1.1)
@@ -165,13 +168,13 @@ importers:
         version: 0.5.1(solid-js@1.7.0)
       tsup:
         specifier: 6.7.0
-        version: 6.7.0(ts-node@10.9.1)(typescript@4.9.5)
+        version: 6.7.0(typescript@4.9.5)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
       vite:
         specifier: 4.2.1
-        version: 4.2.1(@types/node@18.15.11)
+        version: 4.2.1
       vite-plugin-solid:
         specifier: 2.6.1
         version: 2.6.1(solid-js@1.7.0)(vite@4.2.1)
@@ -186,7 +189,7 @@ importers:
         version: 5.16.5
       '@testing-library/vue':
         specifier: 7.0.0
-        version: 7.0.0(@vue/compiler-sfc@3.2.47)(vue@3.2.47)
+        version: 7.0.0(vue@3.2.47)
       '@types/jsdom':
         specifier: 21.1.1
         version: 21.1.1
@@ -210,13 +213,13 @@ importers:
         version: 21.1.1
       tsup:
         specifier: 6.7.0
-        version: 6.7.0(ts-node@10.9.1)(typescript@4.9.5)
+        version: 6.7.0(typescript@4.9.5)
       typescript:
         specifier: 4.9.5
         version: 4.9.5
       vite:
         specifier: 4.2.1
-        version: 4.2.1(@types/node@18.15.11)
+        version: 4.2.1
       vitest:
         specifier: 0.29.8
         version: 0.29.8(jsdom@21.1.1)
@@ -463,6 +466,15 @@ packages:
       '@babel/types': 7.21.2
     dev: true
 
+  /@babel/plugin-syntax-jsx@7.18.6:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.21.0):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
@@ -483,14 +495,13 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-react-jsx-development@7.18.6(@babel/core@7.21.0):
+  /@babel/plugin-transform-react-jsx-development@7.18.6:
     resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.0
-      '@babel/plugin-transform-react-jsx': 7.21.0(@babel/core@7.21.0)
+      '@babel/plugin-transform-react-jsx': 7.21.0
     dev: true
 
   /@babel/plugin-transform-react-jsx-self@7.21.0(@babel/core@7.21.0):
@@ -513,17 +524,16 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-react-jsx@7.21.0(@babel/core@7.21.0):
+  /@babel/plugin-transform-react-jsx@7.21.0:
     resolution: {integrity: sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.0
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.0)
+      '@babel/plugin-syntax-jsx': 7.18.6
       '@babel/types': 7.21.2
     dev: true
 
@@ -1550,22 +1560,21 @@ packages:
       fastq: 1.15.0
     dev: true
 
-  /@preact/preset-vite@2.5.0(@babel/core@7.21.0)(preact@10.13.2)(vite@4.2.1):
+  /@preact/preset-vite@2.5.0(preact@10.13.2)(vite@4.2.1):
     resolution: {integrity: sha512-BUhfB2xQ6ex0yPkrT1Z3LbfPzjpJecOZwQ/xJrXGFSZD84+ObyS//41RdEoQCMWsM0t7UHGaujUxUBub7WM1Jw==}
     peerDependencies:
       '@babel/core': 7.x
       vite: 2.x || 3.x || 4.x
     dependencies:
-      '@babel/core': 7.21.0
-      '@babel/plugin-transform-react-jsx': 7.21.0(@babel/core@7.21.0)
-      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.21.0)
+      '@babel/plugin-transform-react-jsx': 7.21.0
+      '@babel/plugin-transform-react-jsx-development': 7.18.6
       '@prefresh/vite': 2.2.9(preact@10.13.2)(vite@4.2.1)
       '@rollup/pluginutils': 4.2.1
-      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.21.0)
+      babel-plugin-transform-hook-names: 1.0.2
       debug: 4.3.4
       kolorist: 1.7.0
       resolve: 1.22.1
-      vite: 4.2.1(@types/node@18.15.11)
+      vite: 4.2.1
     transitivePeerDependencies:
       - preact
       - supports-color
@@ -1599,7 +1608,7 @@ packages:
       '@prefresh/utils': 1.1.3
       '@rollup/pluginutils': 4.2.1
       preact: 10.13.2
-      vite: 4.2.1(@types/node@18.15.11)
+      vite: 4.2.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -1697,7 +1706,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@testing-library/vue@7.0.0(@vue/compiler-sfc@3.2.47)(vue@3.2.47):
+  /@testing-library/vue@7.0.0(vue@3.2.47):
     resolution: {integrity: sha512-JU/q93HGo2qdm1dCgWymkeQlfpC0/0/DBZ2nAHgEAsVZxX11xVIxT7gbXdI7HACQpUbsUWt1zABGU075Fzt9XQ==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -1706,7 +1715,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.21.0
       '@testing-library/dom': 9.2.0
-      '@vue/compiler-sfc': 3.2.47
       '@vue/test-utils': 2.3.2(vue@3.2.47)
       vue: 3.2.47
     dev: true
@@ -2035,7 +2043,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.21.0)
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.2.1(@types/node@18.15.11)
+      vite: 4.2.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2050,7 +2058,7 @@ packages:
       '@babel/core': 7.21.0
       '@babel/plugin-transform-typescript': 7.21.0(@babel/core@7.21.0)
       '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.21.0)
-      vite: 4.2.1(@types/node@18.15.11)
+      vite: 4.2.1
       vue: 3.2.47
     transitivePeerDependencies:
       - supports-color
@@ -2063,7 +2071,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.2.1(@types/node@18.15.11)
+      vite: 4.2.1
       vue: 3.2.47
     dev: true
 
@@ -2435,12 +2443,10 @@ packages:
       validate-html-nesting: 1.2.1
     dev: true
 
-  /babel-plugin-transform-hook-names@1.0.2(@babel/core@7.21.0):
+  /babel-plugin-transform-hook-names@1.0.2:
     resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
     peerDependencies:
       '@babel/core': ^7.12.10
-    dependencies:
-      '@babel/core': 7.21.0
     dev: true
 
   /babel-preset-solid@1.6.10(@babel/core@7.21.0):
@@ -5096,7 +5102,7 @@ packages:
       pathe: 1.1.0
     dev: true
 
-  /postcss-load-config@3.1.4(ts-node@10.9.1):
+  /postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
     engines: {node: '>= 10'}
     peerDependencies:
@@ -5109,7 +5115,6 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.6
-      ts-node: 10.9.1(@types/node@18.15.11)(typescript@4.9.5)
       yaml: 1.10.2
     dev: true
 
@@ -5954,7 +5959,7 @@ packages:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
-  /tsup@6.6.3(ts-node@10.9.1)(typescript@4.9.5):
+  /tsup@6.6.3(typescript@4.9.5):
     resolution: {integrity: sha512-OLx/jFllYlVeZQ7sCHBuRVEQBBa1tFbouoc/gbYakyipjVQdWy/iQOvmExUA/ewap9iQ7tbJf9pW0PgcEFfJcQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -5978,7 +5983,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.9.1)
+      postcss-load-config: 3.1.4
       resolve-from: 5.0.0
       rollup: 3.17.2
       source-map: 0.8.0-beta.0
@@ -5990,7 +5995,7 @@ packages:
       - ts-node
     dev: true
 
-  /tsup@6.7.0(ts-node@10.9.1)(typescript@4.9.5):
+  /tsup@6.7.0(typescript@4.9.5):
     resolution: {integrity: sha512-L3o8hGkaHnu5TdJns+mCqFsDBo83bJ44rlK7e6VdanIvpea4ArPcU3swWGsLVbXak1PqQx/V+SSmFPujBK+zEQ==}
     engines: {node: '>=14.18'}
     hasBin: true
@@ -6014,7 +6019,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 3.1.4(ts-node@10.9.1)
+      postcss-load-config: 3.1.4
       resolve-from: 5.0.0
       rollup: 3.19.1
       source-map: 0.8.0-beta.0
@@ -6288,10 +6293,43 @@ packages:
       merge-anything: 5.1.4
       solid-js: 1.7.0
       solid-refresh: 0.5.0(solid-js@1.7.0)
-      vite: 4.2.1(@types/node@18.15.11)
+      vite: 4.2.1
       vitefu: 0.2.4(vite@4.2.1)
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /vite@4.2.1:
+    resolution: {integrity: sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.17.12
+      postcss: 8.4.21
+      resolve: 1.22.1
+      rollup: 3.19.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /vite@4.2.1(@types/node@18.15.10):
@@ -6328,40 +6366,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite@4.2.1(@types/node@18.15.11):
-    resolution: {integrity: sha512-7MKhqdy0ISo4wnvwtqZkjke6XN4taqQ2TBaTccLIpOKv7Vp2h4Y+NpmWCnGDeSvvn45KxvWgGyb0MkHvY1vgbg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      '@types/node': 18.15.11
-      esbuild: 0.17.12
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 3.19.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
   /vitefu@0.2.4(vite@4.2.1):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
@@ -6370,7 +6374,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 4.2.1(@types/node@18.15.11)
+      vite: 4.2.1
     dev: true
 
   /vitest@0.29.8(jsdom@21.1.1):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       clean-package:
         specifier: 2.2.0
         version: 2.2.0
+      csstype:
+        specifier: 3.1.1
+        version: 3.1.1
       jsdom:
         specifier: 21.1.1
         version: 21.1.1


### PR DESCRIPTION
## react, preact and solid

When using the `as` prop, the `ref` will now be typed accordingly.

## react

Removed the member `defaultProps` from the type `ComponentWithAs` to support React 18.3.0.