### PR TITLE
fix: remove `ElementType` from union in `MergeWithAs`

### DIFF
--- a/packages/react/src/forwardRef.tsx
+++ b/packages/react/src/forwardRef.tsx
@@ -55,7 +55,7 @@ type MergeWithAs<
        * overriding props but also because somehow it is needed to get the props correctly,
        * Merge does clone the first object so that might have something to do with it.
        */
-      | Assign<DefaultProps, PermanentProps & { as?: Default | ElementType }>
+      | Assign<DefaultProps, PermanentProps & { as?: Default }>
         | Assign<ComponentProps, PermanentProps & { as?: Component }>
     : never
 


### PR DESCRIPTION
Fixes #337.