### PR TITLE
fix(vue): handle input without vmodel

### DIFF
--- a/.changeset/fast-ravens-enjoy.md
+++ b/.changeset/fast-ravens-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@polymorphic-factory/vue': patch
+---
+
+fix polymorphic input

--- a/packages/vue/src/polymorphic-factory.tsx
+++ b/packages/vue/src/polymorphic-factory.tsx
@@ -20,17 +20,17 @@ export type ComponentWithAs<
   Component extends ElementType,
   P extends Record<string, unknown> = Record<never, never>,
 > = {
-  new(): {
+  new (): {
     $props: AllowedComponentProps &
-    ComponentCustomProps &
-    VNodeProps &
-    ExtractPropTypes<Component> &
-    (Component extends keyof IntrinsicElementAttributes
-      ? IntrinsicElementAttributes[Component]
-      : Record<never, never>) &
-    P & {
-      as?: ElementType
-    }
+      ComponentCustomProps &
+      VNodeProps &
+      ExtractPropTypes<Component> &
+      (Component extends keyof IntrinsicElementAttributes
+        ? IntrinsicElementAttributes[Component]
+        : Record<never, never>) &
+      P & {
+        as?: ElementType
+      }
   }
 }
 
@@ -63,11 +63,7 @@ function defaultStyled(originalComponent: ElementType) {
         getAttributes(Component as string, props.modelValue, emit, attrs),
       )
 
-      return () => (
-        <Component {...componentAttrs.value}>
-          {() => slots?.default?.()}
-        </Component>
-      )
+      return () => <Component {...componentAttrs.value}>{() => slots?.default?.()}</Component>
     },
   }) as ComponentWithAs<never>
 }

--- a/packages/vue/src/polymorphic-factory.tsx
+++ b/packages/vue/src/polymorphic-factory.tsx
@@ -10,7 +10,7 @@ import {
   computed,
 } from 'vue'
 import type { IntrinsicElementAttributes } from './dom.types'
-import { useVModel } from './use-v-model'
+import { getAttributes } from './use-v-model'
 
 export type DOMElements = keyof IntrinsicElementAttributes
 
@@ -20,17 +20,17 @@ export type ComponentWithAs<
   Component extends ElementType,
   P extends Record<string, unknown> = Record<never, never>,
 > = {
-  new (): {
+  new(): {
     $props: AllowedComponentProps &
-      ComponentCustomProps &
-      VNodeProps &
-      ExtractPropTypes<Component> &
-      (Component extends keyof IntrinsicElementAttributes
-        ? IntrinsicElementAttributes[Component]
-        : Record<never, never>) &
-      P & {
-        as?: ElementType
-      }
+    ComponentCustomProps &
+    VNodeProps &
+    ExtractPropTypes<Component> &
+    (Component extends keyof IntrinsicElementAttributes
+      ? IntrinsicElementAttributes[Component]
+      : Record<never, never>) &
+    P & {
+      as?: ElementType
+    }
   }
 }
 
@@ -59,13 +59,13 @@ function defaultStyled(originalComponent: ElementType) {
     emits: ['update:modelValue', 'input', 'change'],
     setup(props, { slots, attrs, emit }) {
       const Component = props.as || originalComponent
-      const vmodelAttrs = computed(() =>
-        useVModel(Component as string, props.modelValue, emit, attrs),
+      const componentAttrs = computed(() =>
+        getAttributes(Component as string, props.modelValue, emit, attrs),
       )
 
       return () => (
-        <Component {...vmodelAttrs.value} {...attrs}>
-          {slots?.default?.()}
+        <Component {...componentAttrs.value}>
+          {() => slots?.default?.()}
         </Component>
       )
     },

--- a/packages/vue/src/use-v-model.ts
+++ b/packages/vue/src/use-v-model.ts
@@ -2,7 +2,10 @@ import { computed, ref } from 'vue'
 
 const formElements = ['input', 'select', 'textarea', 'fieldset', 'datalist', 'option', 'optgroup']
 
-const handleMultipleCheckbox = <TModelValue extends Array<any>>(value: unknown, modelValue: TModelValue) => {
+function handleMultipleCheckbox<TModelValue extends Array<any>>(
+  value: unknown,
+  modelValue: TModelValue,
+) {
   const currentModelValue = [...modelValue]
   // If the value is already checked, uncheck it
   // else, add it to the checked array.
@@ -18,9 +21,9 @@ const handleMultipleCheckbox = <TModelValue extends Array<any>>(value: unknown, 
  * Function that emits the right events when using v-model.
  */
 function handleInput<
-  TEmit extends CallableFunction, 
+  TEmit extends CallableFunction,
   TModelValue extends Array<any>,
-  TAttrs extends Record<string, unknown>
+  TAttrs extends Record<string, unknown>,
 >(e: Event, emit: TEmit, modelValue: TModelValue, attrs: TAttrs) {
   emit(
     'update:modelValue',
@@ -41,22 +44,15 @@ function handleInput<
 }
 
 export function getAttributes<
-  TModelValue extends Array<any>, 
-  TEmit extends CallableFunction, 
-  TAttrs extends Record<string, unknown>>
-(
-  elementTag: string,
-  modelValue: TModelValue,
-  emit: TEmit,
-  attrs: TAttrs,
-) {
-  
+  TModelValue extends Array<any>,
+  TEmit extends CallableFunction,
+  TAttrs extends Record<string, unknown>,
+>(elementTag: string, modelValue: TModelValue, emit: TEmit, attrs: TAttrs) {
   const val = ref<Record<string, unknown>>({ value: modelValue })
   const attributes = ref({ ...attrs })
 
   // Only do this if v-model directive is provided, otherwise return user props
   if (formElements.includes(elementTag) && (modelValue !== null || modelValue !== undefined)) {
-    
     if (elementTag === 'input' && (attrs.type === 'checkbox' || attrs.type === 'radio')) {
       const isChecked = computed(() =>
         // If it's a boolean, it's probably a single checkbox or a radio button
@@ -72,9 +68,9 @@ export function getAttributes<
     attributes.value = {
       ...val.value,
       onInput: (e: Event) => handleInput(e, emit, modelValue, attrs),
-      ...attrs
+      ...attrs,
     }
   }
-  
+
   return attributes.value
 }

--- a/packages/vue/src/use-v-model.ts
+++ b/packages/vue/src/use-v-model.ts
@@ -1,59 +1,80 @@
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 
 const formElements = ['input', 'select', 'textarea', 'fieldset', 'datalist', 'option', 'optgroup']
 
-export const useVModel = (
-  elementTag: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  modelValue: any,
-  emit: CallableFunction,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  attrs: any,
-) => {
-  let vmodelAttrs = {}
-  const handleMultipleCheckbox = (value: unknown) => {
-    const currentModelValue = [...modelValue]
-    if (currentModelValue.includes(value)) {
-      currentModelValue.splice(currentModelValue.indexOf(value), 1)
-      return currentModelValue
-    } else {
-      return [...currentModelValue, value]
-    }
+const handleMultipleCheckbox = <TModelValue extends Array<any>>(value: unknown, modelValue: TModelValue) => {
+  const currentModelValue = [...modelValue]
+  // If the value is already checked, uncheck it
+  // else, add it to the checked array.
+  if (currentModelValue.includes(value)) {
+    currentModelValue.splice(currentModelValue.indexOf(value), 1)
+    return currentModelValue
+  } else {
+    return [...currentModelValue, value]
   }
-  const handleInput = (e: Event) => {
-    emit(
-      'update:modelValue',
-      attrs.type === 'checkbox' && Array.isArray(modelValue)
-        ? handleMultipleCheckbox((e?.currentTarget as HTMLInputElement)?.value)
-        : typeof modelValue === 'boolean'
-        ? (e?.currentTarget as HTMLInputElement)?.checked
-        : (e?.currentTarget as HTMLInputElement)?.value,
-    )
-    emit('input', e, (e?.currentTarget as HTMLInputElement)?.value)
-    emit(
-      'change',
-      e,
-      typeof modelValue === 'boolean'
-        ? (e?.currentTarget as HTMLInputElement)?.checked
-        : (e?.currentTarget as HTMLInputElement)?.value,
-    )
-  }
+}
 
-  if (formElements.includes(elementTag)) {
-    let val: Record<string, unknown> = { value: modelValue }
+/**
+ * Function that emits the right events when using v-model.
+ */
+function handleInput<
+  TEmit extends CallableFunction, 
+  TModelValue extends Array<any>,
+  TAttrs extends Record<string, unknown>
+>(e: Event, emit: TEmit, modelValue: TModelValue, attrs: TAttrs) {
+  emit(
+    'update:modelValue',
+    attrs.type === 'checkbox' && Array.isArray(modelValue)
+      ? handleMultipleCheckbox((e?.currentTarget as HTMLInputElement)?.value, modelValue)
+      : typeof modelValue === 'boolean'
+      ? (e?.currentTarget as HTMLInputElement)?.checked
+      : (e?.currentTarget as HTMLInputElement)?.value,
+  )
+  emit('input', e, (e?.currentTarget as HTMLInputElement)?.value)
+  emit(
+    'change',
+    e,
+    typeof modelValue === 'boolean'
+      ? (e?.currentTarget as HTMLInputElement)?.checked
+      : (e?.currentTarget as HTMLInputElement)?.value,
+  )
+}
+
+export function getAttributes<
+  TModelValue extends Array<any>, 
+  TEmit extends CallableFunction, 
+  TAttrs extends Record<string, unknown>>
+(
+  elementTag: string,
+  modelValue: TModelValue,
+  emit: TEmit,
+  attrs: TAttrs,
+) {
+  
+  const val = ref<Record<string, unknown>>({ value: modelValue })
+  const attributes = ref({ ...attrs })
+
+  // Only do this if v-model directive is provided, otherwise return user props
+  if (formElements.includes(elementTag) && (modelValue !== null || modelValue !== undefined)) {
+    
     if (elementTag === 'input' && (attrs.type === 'checkbox' || attrs.type === 'radio')) {
       const isChecked = computed(() =>
+        // If it's a boolean, it's probably a single checkbox or a radio button
+        // If it's not, it's multiple checkboxes
         typeof modelValue === 'boolean' ? modelValue : modelValue.includes(attrs.value),
       )
-      val = {
+
+      val.value = {
         checked: isChecked.value,
       }
     }
-    vmodelAttrs = {
-      ...val,
-      onInput: handleInput,
+
+    attributes.value = {
+      ...val.value,
+      onInput: (e: Event) => handleInput(e, emit, modelValue, attrs),
+      ...attrs
     }
   }
-
-  return vmodelAttrs
+  
+  return attributes.value
 }

--- a/packages/vue/test/poly-test.vue
+++ b/packages/vue/test/poly-test.vue
@@ -20,9 +20,9 @@ const singleCheckbox = ref(true)
   <poly.p>selected : {{ selectValue }}</poly.p>
 
   <poly.div>
-    <poly.input type="radio" v-model="radioValue" value="vue"></poly.input>
-    <poly.input type="radio" value="react" v-model="radioValue" data-testid="react-radio"></poly.input>
-    <poly.input type="radio" value="angular" v-model="radioValue"></poly.input>
+    <poly.input name="framework" type="radio" v-model="radioValue" value="vue"></poly.input>
+    <poly.input name="framework" type="radio" value="react" v-model="radioValue" data-testid="react-radio"></poly.input>
+    <poly.input name="framework" type="radio" value="angular" v-model="radioValue"></poly.input>
   </poly.div>
   <poly.p>Radio: {{ radioValue }}</poly.p>
 


### PR DESCRIPTION
This PR aims to fix a bug with `poly.input` in Vue.

Currently, calling `poly.input` without the `v-model` directive, always trigger the `v-model` logic for it, which messes with the events. 

This PR solves it by only calling the vmodel code when necessary. If no v-model is provided, return user props.

This PR also contains : 

- Small refactor for better readability
- Added comments on methods to explain what they do 
- Replaced `let` with `ref` for better reactivity. 
- Return a function as a slot for better performance and also to get rid off the Vue warning.
- Updated the tests for the radio button ( without the name the test doesn't make much sense )